### PR TITLE
Depend on "railties" instead of "rails".

### DIFF
--- a/aws-sdk-rails.gemspec
+++ b/aws-sdk-rails.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |spec|
   spec.files         += Dir['lib/**/*.rb', 'lib/aws-sdk-rails.rb']
 
   spec.add_dependency('aws-sdk-resources', '~> 2')
-  spec.add_dependency('rails', '>= 3')
+  spec.add_dependency('railties', '>= 3')
 end


### PR DESCRIPTION
Drops ActiveRecord and other dependencies for applications that only use parts of Rails suite.