### PR TITLE
Ensure aws-sdk-rails.initialize executes before load_config_initializers

### DIFF
--- a/lib/aws-sdk-rails.rb
+++ b/lib/aws-sdk-rails.rb
@@ -7,7 +7,7 @@ module Aws
 
     # @api private
     class Railtie < ::Rails::Railtie
-      initializer "aws-sdk-rails.initialize" do |app|
+      initializer "aws-sdk-rails.initialize", before: :load_config_initializers do |app|
         # Initialization Actions
         Aws::Rails.add_action_mailer_delivery_method
         Aws::Rails.log_to_rails_logger


### PR DESCRIPTION
When `aws-sdk-rails.initialize` is executed after `:load_config_initializers` in some cases, `aws_sdk_settings` is overwritten with an empty hash (https://github.com/tsuwatch/aws-sdk-rails/blob/7925051f12d087964ac3ca8f564c09a2e46e7563/lib/aws-sdk-rails.rb#L27) .
