### PR TITLE
[WIP] Add support for amazon pinpoint email delivery 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+
+## [Unreleased]
+------------------
+### Added
+* Added support for email delivery using AWS Pinpoint.
+* Added `aws-sdk-pinpointemail` as a dependency
+
+### Changed
+* Updated references and links to the appropriate v3 documentation
+
+### Deprecated
+* In order to better support different mail services, deprecate `:aws_sdk` for `:ses_mailer` and `:pinpoint_mailer`.
+
 2.0.1 (2017-10-03)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -13,14 +13,13 @@ be added to your Rails environment:
 ```ruby
 gem 'aws-sdk-rails'
 ```
-
-This dependency will automatically pull the core gem for version 3 of the AWS SDK for Ruby. It
-also brings in the `aws-sdk-ses` and `aws-sdk-sts` gems. You will still need to add other
-service gems you need to your Gemfile. For example:
+This `aws-sdk-rails` brings in the `aws-sdk-ses` and `aws-sdk-pinpointemail` gems. This dependency
+will automatically pull the `aws-sdk-core` gem for version 3 of the AWS SDK for Ruby. You will still
+need to add other service gems you need to your Gemfile. For example:
 
 ```ruby
-gem 'aws-sdk-rails', '~> 2'
-gem 'aws-sdk-s3', '~> 1'
+gem 'aws-sdk-rails'
+gem 'aws-sdk-s3'
 ```
 
 You will have to ensure that you provide credentials for the SDK to use. See the
@@ -43,7 +42,7 @@ require 'json'
 secrets = JSON.load(File.read('path/to/aws_secrets.json'))
 
 creds = Aws::Credentials.new(secrets['AccessKeyId'], secrets['SecretAccessKey'])
-Aws::Rails.add_action_mailer_delivery_method(:aws_sdk, credentials: creds, region: 'us-east-1')
+Aws::Rails.add_action_mailer_delivery_method(:ses_mailer, credentials: creds, region: 'us-east-1')
 ```
 
 Or, if you are storing your AWS keys using Rails 5.2's [Encrypted
@@ -60,7 +59,7 @@ use the following initializer code instead:
 keys = Rails.application.credentials[:aws]
 
 creds = Aws::Credentials.new(keys[:access_key_id], keys[:secret_access_key])
-Aws::Rails.add_action_mailer_delivery_method(:aws_sdk, credentials: creds, region: "us-east-1")
+Aws::Rails.add_action_mailer_delivery_method(:ses_mailer, credentials: creds, region: "us-east-1")
 ```
 
 If you're running your Ruby on Rails application on Amazon Elastic Compute
@@ -73,7 +72,7 @@ EC2 instance metadata for credentials. Learn more:
 Automatically, the AWS SDK for Ruby will be configured to use the built-in Rails
 logger for any SDK log output.
 
-## Using Amazon SES as an ActionMailer Delivery Method
+## Using Amazon SES or Amazon Pinpoint as an ActionMailer Delivery Method
 
 The gem will set this up automatically, with an example of doing this manually
 above. With the delivery method in place, you simply need to configure Rails
@@ -81,7 +80,30 @@ to use SES as a delivery method in your environment configuration:
 
 ```ruby
 # for e.g.: RAILS_ROOT/config/environments/production.rb
-config.action_mailer.delivery_method = :aws_sdk
+config.action_mailer.delivery_method = :ses_mailer
 ```
 
-With this in place, the AWS SDK's SES client will be used by ActionMailer.
+or for Pinpoint delivery
+
+```ruby
+# for e.g.: RAILS_ROOT/config/environments/production.rb
+config.action_mailer.delivery_method = :pinpoint_mailer
+```
+
+
+With this in place, the AWS SDK's SES or Pinpoint client will be used by ActionMailer.
+
+## Troubleshooting delivery
+
+If you want to test locally be sure to modify your mailer settings on development
+
+```ruby
+# for e.g.: RAILS_ROOT/config/environments/development.rb
+config.action_mailer.delivery_method = :ses_mailer
+# Make sure rails doesn't swallow any connection/permissions issues with AWS
+config.action_mailer.raise_delivery_errors = true
+config.action_mailer.perform_deliveries = true
+```
+
+It is important to note that you're using an IAM role/user/instance profile that
+it has granted permissions for `ses:SendRawEmail`

--- a/aws-sdk-rails.gemspec
+++ b/aws-sdk-rails.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.files         += Dir['lib/**/*.rb', 'lib/aws-sdk-rails.rb']
 
-  spec.add_dependency('aws-sdk-ses', '~> 1')
+  spec.add_dependency('aws-sdk-ses')
+  spec.add_dependency('aws-sdk-pinpointemail')
   spec.add_dependency('railties', '>= 3')
 end

--- a/lib/aws-sdk-rails.rb
+++ b/lib/aws-sdk-rails.rb
@@ -1,4 +1,6 @@
-require_relative 'aws/rails/mailer'
+require_relative 'aws/rails/ses_mailer'
+require_relative 'aws/rails/pinpoint_mailer'
+require_relative 'aws/rails/aws_sdk'
 
 module Aws
   module Rails
@@ -7,7 +9,10 @@ module Aws
     class Railtie < ::Rails::Railtie
       initializer "aws-sdk-rails.initialize", before: :load_config_initializers do |app|
         # Initialization Actions
-        Aws::Rails.add_action_mailer_delivery_method
+        [:ses_mailer, :pinpoint_mailer, :aws_sdk].each do |name|
+          Aws::Rails.add_action_mailer_delivery_method name
+        end
+
         Aws::Rails.log_to_rails_logger
       end
     end
@@ -20,9 +25,9 @@ module Aws
     #   register.
     # @param [Hash] options The options you wish to pass on to the
     #   Aws::SES::Client initialization method.
-    def self.add_action_mailer_delivery_method(name = :aws_sdk, options = {})
+    def self.add_action_mailer_delivery_method(name = :ses_mailer, options = {})
       ActiveSupport.on_load(:action_mailer) do
-        self.add_delivery_method(name, Aws::Rails::Mailer, options)
+        self.add_delivery_method(name, "Aws::Rails::#{name.to_s.classify}".constantize, options)
       end
     end
 

--- a/lib/aws/rails/aws_sdk.rb
+++ b/lib/aws/rails/aws_sdk.rb
@@ -1,0 +1,4 @@
+# In order to make legacy versions backward compatible create
+# an alias that supports deprecated delivery method of `:aws_sdk` 
+# so users can still use `config.action_mailer.delivery_method = :aws_sdk`
+Aws::Rails::AwsSdk = Aws::Rails::SesMailer

--- a/lib/aws/rails/pinpoint_mailer.rb
+++ b/lib/aws/rails/pinpoint_mailer.rb
@@ -1,0 +1,50 @@
+require 'aws-sdk-pinpoint'
+
+module Aws
+  module Rails
+
+    # Provides a delivery method for ActionMailer that uses Amazon Simple Email
+    # Service.
+    # 
+    # Once you have an PinpointEmail delivery method you can configure Rails to
+    # use this for ActionMailer in your environment configuration
+    # (e.g. RAILS_ROOT/config/environments/production.rb)
+    #
+    #     config.action_mailer.delivery_method = :pinpoint_mailer
+    #
+    # Uses the AWS SDK for Ruby V3's credential provider chain when creating an
+    # PinpointEmail client instance.
+    class PinpointMailer
+
+      # @param [Hash] options Passes along initialization options to
+      #   [Aws::PinpointEmail::Client.new](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/PinpointEmail/Client.html#initialize-instance_method).
+      def initialize(options = {})
+        @client = PinpointEmail::Client.new(options)
+      end
+
+      # Rails expects this method to exist, and to handle a Mail::Message object
+      # correctly. Called during mail delivery.
+      def deliver!(message)
+        send_opts = {}
+
+        #https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/PinpointEmail/Types/EmailContent.html
+        send_opts[:content] = {}
+        send_opts[:content][:raw] = { data: message.to_s }
+        
+        # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/PinpointEmail/Types/Destination.html
+        send_opts[:destination] = {}
+        send_opts[:destination][:to_addresses] = [*message.to]
+        send_opts[:destination][:cc_addresses] = [*message.cc]
+        send_opts[:destination][:bcc_addresses] = [*message.bcc]
+
+        @client.send_email(send_opts)
+      end
+
+      # ActionMailer expects this method to be present and to return a hash.
+      def settings
+        {}
+      end
+
+    end
+  end
+end

--- a/lib/aws/rails/pinpoint_mailer.rb
+++ b/lib/aws/rails/pinpoint_mailer.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk-pinpoint'
+require 'aws-sdk-pinpointemail'
 
 module Aws
   module Rails

--- a/lib/aws/rails/ses_mailer.rb
+++ b/lib/aws/rails/ses_mailer.rb
@@ -10,14 +10,14 @@ module Aws
     # use this for ActionMailer in your environment configuration
     # (e.g. RAILS_ROOT/config/environments/production.rb)
     #
-    #     config.action_mailer.delivery_method = :aws_sdk
+    #     config.action_mailer.delivery_method = :ses_mailer
     #
-    # Uses the AWS SDK for Ruby V2's credential provider chain when creating an
+    # Uses the AWS SDK for Ruby V3's credential provider chain when creating an
     # SES client instance.
-    class Mailer
+    class SesMailer
 
       # @param [Hash] options Passes along initialization options to
-      #   [Aws::SES::Client.new](http://docs.aws.amazon.com/sdkforruby/api/Aws/SES/Client.html#initialize-instance_method).
+      #   [Aws::SES::Client.new](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SES/Client.html#initialize-instance_method).
       def initialize(options = {})
         @client = SES::Client.new(options)
       end

--- a/test/aws/rails/aws_sdk_test.rb
+++ b/test/aws/rails/aws_sdk_test.rb
@@ -3,10 +3,10 @@ require 'mail'
 
 module Aws
   module Rails
-    class MailerTest < Minitest::Test
+    class AwsSdkTest < Minitest::Test
 
       def setup
-        @mailer = Mailer.new(stub_responses: true)
+        @mailer = AwsSdk.new(stub_responses: true)
       end
 
       def sample_message

--- a/test/aws/rails/pinpoint_mailer_test.rb
+++ b/test/aws/rails/pinpoint_mailer_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+require 'mail'
+
+module Aws
+  module Rails
+    class PinpointMailerTest < Minitest::Test
+
+      def setup
+        @mailer = PinpointMailer.new(stub_responses: true)
+      end
+
+      def sample_message
+        Mail.new do
+          from    'sender@example.com'
+          to      'recipient@example.com'
+          subject 'This is a test'
+          body    'Hallo'
+        end
+      end
+
+      def test_settings_method
+        expected = {}
+        assert_equal expected, @mailer.settings
+      end
+
+      def test_deliver
+        message = sample_message
+        resp = @mailer.deliver!(message)
+        assert_equal resp.context.params[:content][:raw][:data].to_s, message.to_s
+        assert_equal resp.context.params[:destination][:to_addresses], message.to
+      end
+
+    end
+  end
+end

--- a/test/aws/rails/ses_mailer_test.rb
+++ b/test/aws/rails/ses_mailer_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+require 'mail'
+
+module Aws
+  module Rails
+    class SesMailerTest < Minitest::Test
+
+      def setup
+        @mailer = SesMailer.new(stub_responses: true)
+      end
+
+      def sample_message
+        Mail.new do
+          from    'sender@example.com'
+          to      'recipient@example.com'
+          subject 'This is a test'
+          body    'Hallo'
+        end
+      end
+
+      def test_settings_method
+        expected = {}
+        assert_equal expected, @mailer.settings
+      end
+
+      def test_deliver
+        message = sample_message
+        resp = @mailer.deliver!(message)
+        assert_equal resp.context.params[:raw_message][:data].to_s, message.to_s
+        assert_equal resp.context.params[:destinations], message.destinations
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Extend by adding support for the `PinpointEmail` API

https://aws.amazon.com/blogs/messaging-and-targeting/exciting-new-email-features-available-now-in-amazon-pinpoint/