### PR TITLE
Record the SES Message ID in the header :ses_message_id

### DIFF
--- a/lib/aws/rails/mailer.rb
+++ b/lib/aws/rails/mailer.rb
@@ -33,8 +33,9 @@ module Aws
           send_opts[:destinations] = message.destinations
         end
 
-        @client.send_raw_email(send_opts)
-
+        @client.send_raw_email(send_opts).tap do |response|
+          message.header[:ses_message_id] = response.message_id
+        end
       end
 
       # ActionMailer expects this method to be present and to return a hash.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,13 +6,13 @@ require 'minitest/autorun'
 class TestMailer < ActionMailer::Base
   layout nil
 
-  def deliverable(body:, from:, subject:, to:)
+  def deliverable(options = {})
     mail(
-      body: body,
+      body: options[:body],
       delivery_method: :aws_sdk,
-      from: from,
-      subject: subject,
-      to: to
+      from: options[:from],
+      subject: options[:subject],
+      to: options[:to]
     )
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,18 @@
-require 'rails'
+require 'rails/railtie'
+require 'action_mailer'
 require 'aws-sdk-rails'
 require 'minitest/autorun'
+
+class TestMailer < ActionMailer::Base
+  layout nil
+
+  def deliverable(body:, from:, subject:, to:)
+    mail(
+      body: body,
+      delivery_method: :aws_sdk,
+      from: from,
+      subject: subject,
+      to: to
+    )
+  end
+end


### PR DESCRIPTION
Following on from #10. Having the message ID is essential for tracking the deliverability (and other events).

**Description of changes:**

Instead of overriding `message_id` as was rejected in #10 I’ve placed the SES Message ID in a new header, so after you deliver a message through ActionMailer you have it available:

``` ruby
message = MyMailer.demo.deliver_now
message.header[:ses_message_id].value
>> "0000000000000000-1111111-2222-3333-4444-555555555555-666666"
```

This is adding the header after it’s sent only. I think it’s a reasonable conduit for passing this data back to the app in this instance.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._