### PR TITLE
Use Rails encrypted credentials

### DIFF
--- a/lib/aws-sdk-rails.rb
+++ b/lib/aws-sdk-rails.rb
@@ -7,9 +7,15 @@ module Aws
     class Railtie < ::Rails::Railtie
       initializer "aws-sdk-rails.initialize", before: :load_config_initializers do |app|
         # Initialization Actions
+        Aws::Rails.use_rails_encrypted_credentials
         Aws::Rails.add_action_mailer_delivery_method
         Aws::Rails.log_to_rails_logger
       end
+    end
+
+    # Configures the AWS SDK with credentials from Rails encrypted credentials
+    def self.use_rails_encrypted_credentials
+      Aws.config.merge!(Rails.application.try(:credentials).try(:aws).to_h)
     end
 
     # This is called automatically from the SDK's Railtie, but if you want to


### PR DESCRIPTION
*Description of changes:*

This change allows the AWS SDK to automatically use `access_key_id` and `secret_access_key` from Rails encrypted credentials.  The values are added to `Aws.config`, and thus become the default for any `AWS::*::Client` (e.g. `AWS::SES::Client`).

With the release of Rails 6, which includes support for multi-environment credentials, I think Rails encrypted credentials is becoming a preferred convention.  So it would be nice to support it out-of-the-box, for all AWS services, with no extra configuration required.

Additionally, the default "config/credentials.yml.enc" file comes with the following example, commented out:

```yaml
# aws:
#   access_key_id: 123
#   secret_access_key: 345
```

Which I think gives credence to using the `:aws` key (i.e. using `Rails.application.credentials.aws`).

Note that this change does not *require* using encrypted credentials.   Default credentials can still be provided via environment variables, and per-service credentials can still be specified as described in the README.

I'm unsure of how best to test this change.  In many Rails gems, there is a dummy app in the test folder where, for example, configuration changes can be applied and tested.  Perhaps here it would be best to stub `Rails.application.credentials`?

Also, if this change is desirable, I'll add documentation to the README.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
