### PR TITLE
Drop support for end-of-life Ruby and Rails; Update CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .bundle
 .yardoc
 *.gem
+*.gemfile.lock
 coverage
 doc
 Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: ruby
 
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1
-  - 2.2
-  - 2.3.0
+  - 2.4
+  - 2.5
+  - 2.6
   - jruby
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,18 @@ rvm:
   - 2.6
   - jruby
 
-sudo: false
+gemfile:
+  - gemfiles/rails-5.2.gemfile
+  - gemfiles/rails-6.0.gemfile
+  - gemfiles/rails-master.gemfile
 
-script: bundle exec rake
+matrix:
+  allow_failures:
+    - gemfile: gemfiles/rails-master.gemfile
+  exclude:
+    - gemfile: gemfiles/rails-master.gemfile
+      rvm: 2.4
+    - gemfile: gemfiles/rails-6.0.gemfile
+      rvm: 2.4
 
 bundler_args: --without docs release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Drop support for Ruby < 2.4 and Rails < 5.2.
+
 2.1.0 (2019-02-14)
 ------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 Unreleased Changes
 ------------------
 
-* Drop support for Ruby < 2.4 and Rails < 5.2.
-
 2.1.0 (2019-02-14)
 ------------------
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,6 @@ group :docs do
   gem 'rdiscount'
 end
 
-group :test do
-  gem 'minitest', '~> 5.5'
-  gem 'rails', '>= 5.2'
-end
-
 group :release do
   gem 'octokit'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 
 group :test do
   gem 'minitest', '~> 5.5'
-  gem 'rails', '>= 3'
+  gem 'rails', '>= 5.2'
 end
 
 group :release do

--- a/aws-sdk-rails.gemspec
+++ b/aws-sdk-rails.gemspec
@@ -15,4 +15,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('aws-sdk-ses', '~> 1')
   spec.add_dependency('railties', '>= 5.2')
+
+  spec.add_development_dependency('rails')
 end

--- a/aws-sdk-rails.gemspec
+++ b/aws-sdk-rails.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |spec|
   spec.files         += Dir['lib/**/*.rb', 'lib/aws-sdk-rails.rb']
 
   spec.add_dependency('aws-sdk-ses', '~> 1')
-  spec.add_dependency('railties', '>= 3')
+  spec.add_dependency('railties', '>= 5.2')
 end

--- a/gemfiles/rails-5.2.gemfile
+++ b/gemfiles/rails-5.2.gemfile
@@ -1,0 +1,3 @@
+eval_gemfile "../Gemfile"
+
+gem "rails", "~> 5.2.0"

--- a/gemfiles/rails-6.0.gemfile
+++ b/gemfiles/rails-6.0.gemfile
@@ -1,0 +1,3 @@
+eval_gemfile "../Gemfile"
+
+gem "rails", "~> 6.0.0"

--- a/gemfiles/rails-master.gemfile
+++ b/gemfiles/rails-master.gemfile
@@ -1,0 +1,3 @@
+eval_gemfile "../Gemfile"
+
+gem "rails", github: "rails/rails"


### PR DESCRIPTION
This PR drops support for end-of-life versions of Ruby and Rails, and updates CI configuration to test against all supported versions.

This is a breaking change.  However, the previous CI configuration only tested against the latest release of Rails, so it is uncertain if the current version of this library works with older Rails versions, anyway.

I can amend this PR to include older versions of Rails, if required, but this seemed like a good opportunity to drop EOL versions.  If apps on older versions of Rails do work with the current major version of this library, they can still continue to use it.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
