### PR TITLE
ActiveSupport::Notifications instrumentation of aws sdk client calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,19 +120,19 @@ message['X-SES-FROM-ARN'] = 'arn:aws:ses:us-west-2:012345678910:identity/bigchun
 message.deliver
 ```
 
-## Adding `ActiveSupport::Notifications` Instrumentation to AWS SDK calls
+## Active Support Notification Instrumentation for AWS SDK calls
 To add `ActiveSupport::Notifications` Instrumentation to all AWS SDK client 
 operations call `Aws::Rails.instrument_sdk_operations` before you construct any
 SDK clients.
 
-Example usage in `config/capplication.rb`
+Example usage in `config/initializers/instrument_aws_sdk.rb`
 ```ruby
 Aws::Rails.instrument_sdk_operations
 ```
 
 Events are published for each client operation call with the following event
 name: <operation>.<serviceId>.aws.  For example, S3's put_object has an event
-name of: put_object.S3.aws.  The payload of the event is the 
+name of: `put_object.S3.aws`.  The payload of the event is the 
 [request context](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Seahorse/Client/RequestContext.html).
 
 You can subscribe to these events as you would other

--- a/README.md
+++ b/README.md
@@ -119,3 +119,32 @@ message = MyMailer.send_email(options)
 message['X-SES-FROM-ARN'] = 'arn:aws:ses:us-west-2:012345678910:identity/bigchungus@memes.com'
 message.deliver
 ```
+
+## Adding `ActiveSupport::Notifications` Instrumentation to AWS SDK calls
+To add `ActiveSupport::Notifications` Instrumentation to all AWS SDK client 
+operations call `Aws::Rails.instrument_sdk_operations` before you construct any
+SDK clients.
+
+Example usage in `config/capplication.rb`
+```ruby
+Aws::Rails.instrument_sdk_operations
+```
+
+Events are published for each client operation call with the following event
+name: <operation>.<serviceId>.aws.  For example, S3's put_object has an event
+name of: put_object.S3.aws.  The payload of the event is the 
+[request context](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Seahorse/Client/RequestContext.html).
+
+You can subscribe to these events as you would other
+ `ActiveSupport::Notifications`:
+ 
+ ```ruby
+ActiveSupport::Notifications.subscribe('put_object.s3.aws') do |name, start, finish, id, payload|
+  # process event
+end
+
+# Or use a regex to subscribe to all service notifications
+ActiveSupport::Notifications.subscribe(/s3[.]aws/) do |name, start, finish, id, payload|
+  # process event
+end
+```

--- a/lib/aws-sdk-rails.rb
+++ b/lib/aws-sdk-rails.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'aws/rails/mailer'
+require_relative 'aws/rails/notifications_instrument_plugin'
 
 module Aws
   # Use the Rails namespace.
@@ -13,6 +14,7 @@ module Aws
         Aws::Rails.use_rails_encrypted_credentials
         Aws::Rails.add_action_mailer_delivery_method
         Aws::Rails.log_to_rails_logger
+        Aws::Rails.add_notifications_instrument_plugin
       end
     end
 
@@ -46,6 +48,20 @@ module Aws
           .try(:aws)
           .to_h.slice(*aws_credential_keys)
       )
+    end
+    
+    def self.add_notifications_instrument_plugin
+      # TODO: Config based.  Enable/disable.
+      # specify which clients get instrumented?
+      Aws.constants.each do|c|
+        m = Aws.const_get(c)
+        if m.is_a?(Module) &&
+          m.const_defined?(:Client) &&
+          m.const_get(:Client).superclass == Seahorse::Client::Base
+
+          m.const_get(:Client).add_plugin(Aws::Rails::NotificationsInstrument)
+        end
+      end
     end
   end
 end

--- a/lib/aws-sdk-rails.rb
+++ b/lib/aws-sdk-rails.rb
@@ -61,7 +61,7 @@ module Aws
         if m.is_a?(Module) &&
            m.const_defined?(:Client) &&
            m.const_get(:Client).superclass == Seahorse::Client::Base
-          m.const_get(:Client).add_plugin(Aws::Rails::NotificationsInstrument)
+          m.const_get(:Client).add_plugin(Aws::Rails::Notifications)
         end
       end
     end

--- a/lib/aws/rails/notifications_instrument_plugin.rb
+++ b/lib/aws/rails/notifications_instrument_plugin.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
 require 'aws-sdk-core'
+require 'active_support/notifications'
 
 module Aws
   module Rails
+
+    # Instruments client operation calls for ActiveSupport::Notifications
+    # Each client operation will produce an event with name:
+    # <operation>.<service>.aws
     # @api private
     class NotificationsInstrument < Seahorse::Client::Plugin
 

--- a/lib/aws/rails/notifications_instrument_plugin.rb
+++ b/lib/aws/rails/notifications_instrument_plugin.rb
@@ -17,8 +17,7 @@ module Aws
       class Handler < Seahorse::Client::Handler
 
         def call(context)
-          # context.operation_name
-          event_name = "aws.#{context.config.api.metadata['serviceId']}.#{context.operation_name}"
+          event_name = "#{context.operation_name}.#{context.config.api.metadata['serviceId']}.aws"
           ActiveSupport::Notifications.instrument(event_name, context: context) do
             @handler.call(context)
           end

--- a/lib/aws/rails/notifications_instrument_plugin.rb
+++ b/lib/aws/rails/notifications_instrument_plugin.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'aws-sdk-core'
+
+module Aws
+  module Rails
+    # @api private
+    class NotificationsInstrument < Seahorse::Client::Plugin
+
+      def add_handlers(handlers, config)
+        handlers.add(Handler, step: :initialize)
+      end
+
+      class Handler < Seahorse::Client::Handler
+
+        def call(context)
+          # TODO: Should this be #{operation_name}.#{service}?
+          ActiveSupport::Notifications.instrument('operation.aws_sdk', context: context) do
+            @handler.call(context)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/aws/rails/notifications_instrument_plugin.rb
+++ b/lib/aws/rails/notifications_instrument_plugin.rb
@@ -10,7 +10,7 @@ module Aws
     # Each client operation will produce an event with name:
     # <operation>.<service>.aws
     # @api private
-    class NotificationsInstrument < Seahorse::Client::Plugin
+    class Notifications < Seahorse::Client::Plugin
 
       def add_handlers(handlers, config)
         # This plugin needs to be first

--- a/spec/aws/rails/notifications_instrument_spec.rb
+++ b/spec/aws/rails/notifications_instrument_spec.rb
@@ -1,0 +1,49 @@
+require_relative '../../spec_helper'
+
+module Aws
+
+  # Test namespaces
+  module Service1; end
+  module Service2; end
+
+  module Rails
+    describe 'NotificationsInstrument' do
+
+      let(:base_client) { Aws::SES::Client }
+
+      describe '.instrument_sdk_operations' do
+        it 'adds the plugin to each AWS Client' do
+          Aws::Service1::Client = base_client.dup
+          Aws::Service2::Client = base_client.dup
+
+          expect(Aws::Service1::Client).to receive(:add_plugin).with(Aws::Rails::NotificationsInstrument)
+          expect(Aws::Service2::Client).to receive(:add_plugin).with(Aws::Rails::NotificationsInstrument)
+
+          # Ensure other Clients don't get plugin added
+          allow_any_instance_of(Class).to receive(:add_plugin)
+
+          Aws::Rails.instrument_sdk_operations
+        end
+      end
+
+      describe 'NotificationsInstrument Plugin' do
+        let(:client) do
+          Client = base_client.dup
+          Client.add_plugin(Aws::Rails::NotificationsInstrument)
+          Client.new(stub_responses: true, logger: nil)
+        end
+
+        it 'adds instrumentation on each call' do
+          out = {}
+          ActiveSupport::Notifications.subscribe(/aws/) do |name, start, finish, id, payload|
+            out[:name] = name
+            out[:payload] = payload
+          end
+          client.get_send_quota
+          expect(out[:name]).to eq('get_send_quota.SES.aws')
+          expect(out[:payload][:context]).to be_a(Seahorse::Client::RequestContext)
+        end
+      end
+    end
+  end
+end

--- a/spec/aws/rails/notifications_spec.rb
+++ b/spec/aws/rails/notifications_spec.rb
@@ -16,8 +16,8 @@ module Aws
           Aws::Service1::Client = base_client.dup
           Aws::Service2::Client = base_client.dup
 
-          expect(Aws::Service1::Client).to receive(:add_plugin).with(Aws::Rails::NotificationsInstrument)
-          expect(Aws::Service2::Client).to receive(:add_plugin).with(Aws::Rails::NotificationsInstrument)
+          expect(Aws::Service1::Client).to receive(:add_plugin).with(Aws::Rails::Notifications)
+          expect(Aws::Service2::Client).to receive(:add_plugin).with(Aws::Rails::Notifications)
 
           # Ensure other Clients don't get plugin added
           allow_any_instance_of(Class).to receive(:add_plugin)
@@ -29,7 +29,7 @@ module Aws
       describe 'NotificationsInstrument Plugin' do
         let(:client) do
           Client = base_client.dup
-          Client.add_plugin(Aws::Rails::NotificationsInstrument)
+          Client.add_plugin(Aws::Rails::Notifications)
           Client.new(stub_responses: true, logger: nil)
         end
 


### PR DESCRIPTION
Fixes: #14 

*Description of changes:*
Support ActiveSupport::Notification instrumentation of all AWS SDK client operations.  

This is currently not enabled by default and requires calling `Aws::Rails.instrument_sdk_operations` (eg, can be done in config/application.rb or in environment configs).  

Instrumentation adds ~0.2ms per call (which is an ~20% increase outside of network calls).

Note: I had to inspect all loaded Aws modules for service modules and add the handler to each one - adding to the seahorse base client does not work at this stage.


Open Questions:
1. Should this be enabled/disabled by config? And if so, should we allow configuration of which clients are instrumented.  Answer: Removed config.  Instrumentation is added by calling `Aws::Rails.instrument_sdk_operations` (See above explanation)
2. What should the name of the event be?  Answer: `<operation>.<serviceId>.aws` (Note, this naming matches the [patterns used in rails](https://edgeguides.rubyonrails.org/active_support_instrumentation.html)).
3. Is there a better way to do this than adding a plugin/handler? Answer: No, this is the best approach here.


By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
