### PR TITLE
Add Ruby 3 and Rails 6.1 to CI Matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,20 +15,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', jruby-9.1, jruby-9.2]
-        gemfile: [gemfiles/rails-5.2.gemfile, gemfiles/rails-6.0.gemfile, gemfiles/rails-master.gemfile]
-        exclude:
-          - gemfile: gemfiles/rails-master.gemfile
+        ruby: [2.5, 2.6, 2.7, '3.0', jruby-9.2]
+        gemfile: [gemfiles/rails-6.0.gemfile, gemfiles/rails-6.1.gemfile, gemfiles/rails-master.gemfile]
+        include:
+          - gemfile: gemfiles/rails-5.2.gemfile
             ruby: 2.3
-          - gemfile: gemfiles/rails-master.gemfile
+          - gemfile: gemfiles/rails-5.2.gemfile
             ruby: 2.4
-          - gemfile: gemfiles/rails-master.gemfile
-            ruby: jruby-9.1
-          - gemfile: gemfiles/rails-6.0.gemfile
-            ruby: 2.3
-          - gemfile: gemfiles/rails-6.0.gemfile
-            ruby: 2.4
-          - gemfile: gemfiles/rails-6.0.gemfile
+          - gemfile: gemfiles/rails-5.2.gemfile
             ruby: jruby-9.1
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
             ruby: 2.4
           - gemfile: gemfiles/rails-5.2.gemfile
             ruby: jruby-9.1
+        exclude:
+          - gemfile: gemfiles/rails-5.2.gemfile
+            ruby: '3.0'
 
     steps:
       - name: Setup Ruby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [2.5, 2.6, 2.7, '3.0', jruby-9.2]
-        gemfile: [gemfiles/rails-6.0.gemfile, gemfiles/rails-6.1.gemfile, gemfiles/rails-master.gemfile]
+        gemfile: [gemfiles/rails-5.2.gemfile, gemfiles/rails-6.0.gemfile, gemfiles/rails-6.1.gemfile, gemfiles/rails-master.gemfile]
         include:
           - gemfile: gemfiles/rails-5.2.gemfile
             ruby: 2.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, jruby-9.1, jruby-9.2]
+        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', jruby-9.1, jruby-9.2]
         gemfile: [gemfiles/rails-5.2.gemfile, gemfiles/rails-6.0.gemfile, gemfiles/rails-master.gemfile]
         exclude:
           - gemfile: gemfiles/rails-master.gemfile
@@ -29,7 +29,7 @@ jobs:
           - gemfile: gemfiles/rails-6.0.gemfile
             ruby: 2.4
           - gemfile: gemfiles/rails-6.0.gemfile
-            ruby: jruby-9.1 
+            ruby: jruby-9.1
 
     steps:
       - name: Setup Ruby

--- a/gemfiles/rails-6.1.gemfile
+++ b/gemfiles/rails-6.1.gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+eval_gemfile '../Gemfile'
+
+gem 'rails', '~> 6.1.0'


### PR DESCRIPTION
*Description of changes:*
* Add ruby-3 to CI matrix
* Add rails 6.1 to CI matrix.
* Refactor to use include for old rails and ruby versions instead of exclude.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
