### PR TITLE
Update CI - remove old ruby versions for new rails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,13 @@ jobs:
         exclude:
           - gemfile: gemfiles/rails-5.2.gemfile
             ruby: '3.0'
+          - gemfile: gemfiles/rails-master.gemfile
+            ruby: 2.5
+          - gemfile: gemfiles/rails-master.gemfile
+            ruby: 2.6
+          - gemfile: gemfiles/rails-master.gemfile
+            ruby: jruby-9.2
+            
 
     steps:
       - name: Setup Ruby


### PR DESCRIPTION
Exclude older Ruby versions from CI matrix for the newest rails.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
