### PR TITLE
Dynamic message group ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,12 +420,18 @@ If the order in which your jobs executes is important, consider using a
 A FIFO queue ensures that messages are processed in the order they were sent
 (First-In-First-Out) and exactly-once processing (ensuring duplicates are never
 introduced into the queue).  To use a fifo queue, simply set the queue url (which will end in ".fifo")
-in your config.  You can also configure a `custom message_group_id` that
-will be used by all jobs.
+in your config.
 
 When using FIFO queues, jobs will NOT be processed concurrently by the poller
 to ensure the correct ordering.  Additionally, all jobs on a FIFO queue will be queued
 synchronously, even if you have configured the `amazon_sqs_async` adapter.
+
+#### Message Group IDs
+
+FIFO queues require a message group id to be provided for the job. It is determined by:
+1. Calling `message_group_id` on the job if it is defined
+2. If `message_group_id` is not defined or the result is `nil`, the default value will be used.
+You can optionally specify a custom value in your config as the default that will be used by all jobs.
 
 ## AWS Record Generators
 

--- a/lib/active_job/queue_adapters/amazon_sqs_adapter.rb
+++ b/lib/active_job/queue_adapters/amazon_sqs_adapter.rb
@@ -30,13 +30,15 @@ module ActiveJob
           # job_id is unique per initialization of job
           # Remove it from message dup id to ensure run-once behavior
           # with ActiveJob retries
-           send_message_opts[:message_deduplication_id] =
-             Digest::SHA256.hexdigest(
-               Aws::Json.dump(body.except('job_id'))
-             )
+          send_message_opts[:message_deduplication_id] =
+            Digest::SHA256.hexdigest(Aws::Json.dump(body.except('job_id')))
 
-           send_message_opts[:message_group_id] = Aws::Rails::SqsActiveJob.config.message_group_id
+          message_group_id = job.message_group_id if job.respond_to?(:message_group_id)
+          message_group_id ||= Aws::Rails::SqsActiveJob.config.message_group_id
+
+          send_message_opts[:message_group_id] = message_group_id
         end
+
         Aws::Rails::SqsActiveJob.config.client.send_message(send_message_opts)
       end
 

--- a/test/active_job/queue_adapters/amazon_sqs_async_adapter_test.rb
+++ b/test/active_job/queue_adapters/amazon_sqs_async_adapter_test.rb
@@ -18,12 +18,13 @@ module ActiveJob
       end
 
       it 'enqueues jobs without blocking' do
-        expect(client).to receive(:send_message)
-          .with(
+        expect(client).to receive(:send_message).with(
+          {
             queue_url: 'https://queue-url',
             message_body: instance_of(String),
             message_attributes: instance_of(Hash)
-          )
+          }
+        )
         expect(Concurrent::Promise).to receive(:execute).and_call_original
 
         TestJob.perform_later('test')

--- a/test/aws/rails/sqs_active_job/poller_test.rb
+++ b/test/aws/rails/sqs_active_job/poller_test.rb
@@ -69,9 +69,11 @@ module Aws
             expect(Aws::SQS::QueuePoller).to receive(:new).and_return(queue_poller)
 
             expect(queue_poller).to receive(:poll).with(
-              skip_delete: true,
-              max_number_of_messages: 5,
-              visibility_timeout: 360
+              {
+                skip_delete: true,
+                max_number_of_messages: 5,
+                visibility_timeout: 360
+              }
             )
 
             poller.run
@@ -84,9 +86,11 @@ module Aws
             expect(Aws::SQS::QueuePoller).to receive(:new).and_return(queue_poller)
 
             expect(queue_poller).to receive(:poll).with(
-              skip_delete: true,
-              max_number_of_messages: 1,
-              visibility_timeout: 360
+              {
+                skip_delete: true,
+                max_number_of_messages: 1,
+                visibility_timeout: 360
+              }
             )
 
             poller.run

--- a/test/aws/rails/sqs_active_job/test_job.rb
+++ b/test/aws/rails/sqs_active_job/test_job.rb
@@ -5,3 +5,7 @@ class TestJob < ActiveJob::Base
   def perform(a1, a2)
   end
 end
+
+class TestJobWithMessageGroupID < TestJob
+  def message_group_id; end
+end


### PR DESCRIPTION
- This fixes the existing failing tests in Ruby 3 that appear to be due to keyword arguments.
- This adds the ability to define a `message_group_id` method on the job that will be called if using a fifo queue.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
