### PR TITLE
Enable automatic message visibility refresh

### DIFF
--- a/lib/aws/rails/sqs_active_job/executor.rb
+++ b/lib/aws/rails/sqs_active_job/executor.rb
@@ -52,10 +52,9 @@ module Aws
                 # Extend the visibility timeout to the provided refresh timeout
                 message.change_visibility({ visibility_timeout: @refresh_timeout })
                 # Wait half the refresh timeout, and repeat
-                sleep(@refresh_timeout / 2)
+                sleep(@refresh_timeout / 2.0)
               rescue => e
                 # If anything goes wrong, we want to handle it. We don't care what.
-                @logger.error("Monitor process failed for message: #{message.id}. Error: #{e}")
               end
             end
           end if @monitor

--- a/lib/aws/rails/sqs_active_job/executor.rb
+++ b/lib/aws/rails/sqs_active_job/executor.rb
@@ -43,7 +43,7 @@ module Aws
               @logger.info "Error processing job #{job_msg}: #{e}"
               @logger.debug e.backtrace.join("\n")
             ensure
-              refresh_visibility = true
+              refresh_visibility = false
             end
           end
 

--- a/lib/aws/rails/sqs_active_job/executor.rb
+++ b/lib/aws/rails/sqs_active_job/executor.rb
@@ -54,10 +54,10 @@ module Aws
                 message.change_visibility({ visibility_timeout: @visibility_refresh })
                 # Wait half the refresh timeout, and repeat
                 sleep(@visibility_refresh / 2.0)
-              rescue Aws::SQS::Errors::ReceiptHandleIsInvalid =>
+              rescue Aws::SQS::Errors::ReceiptHandleIsInvalid
                 # Message has been deleted. We don't care!
                 break
-              rescue Aws::SQS::Errors::MessageNotInflight => e
+              rescue Aws::SQS::Errors::MessageNotInflight
                 # Message has been otherwise released. We don't care!
                 break
               rescue => e

--- a/lib/aws/rails/sqs_active_job/executor.rb
+++ b/lib/aws/rails/sqs_active_job/executor.rb
@@ -49,9 +49,9 @@ module Aws
           @monitor.post(message) do |message|
             while poison_pill
               begin
-                # Extend the visibility timeout by one minute
-                message.change_visibility({ visibility_timeout: 1.minute })
-                # Wait 30 seconds, and repeat
+                # Extend the visibility timeout to the provided refresh timeout
+                message.change_visibility({ visibility_timeout: @refresh_timeout })
+                # Wait half the refresh timeout, and repeat
                 sleep(@refresh_timeout / 2)
               rescue => e
                 # If anything goes wrong, we want to handle it. We don't care what.

--- a/lib/aws/rails/sqs_active_job/executor.rb
+++ b/lib/aws/rails/sqs_active_job/executor.rb
@@ -46,7 +46,10 @@ module Aws
               refresh_monitor = false
             end
           end
+          refresh_monitor(message, refresh_monitor) if @visibility_refresh
+        end
 
+        def refresh_monitor(message, refresh_monitor)
           @monitor.post(message) do |message|
             while refresh_monitor
               begin
@@ -66,7 +69,7 @@ module Aws
                 break
               end
             end
-          end if @visibility_refresh
+          end
         end
 
         def shutdown(timeout=nil)

--- a/lib/aws/rails/sqs_active_job/executor.rb
+++ b/lib/aws/rails/sqs_active_job/executor.rb
@@ -54,8 +54,11 @@ module Aws
                 message.change_visibility({ visibility_timeout: @visibility_refresh })
                 # Wait half the refresh timeout, and repeat
                 sleep(@visibility_refresh / 2.0)
+              rescue Aws::SQS::Errors::ReceiptHandleIsInvalid =>
+                # Message has been deleted. We don't care!
+                break
               rescue Aws::SQS::Errors::MessageNotInflight => e
-                # Message has been deleted or otherwise released. We don't care!
+                # Message has been otherwise released. We don't care!
                 break
               rescue => e
                 # If anything else goes wrong, we should log and break the loop.

--- a/lib/aws/rails/sqs_active_job/executor.rb
+++ b/lib/aws/rails/sqs_active_job/executor.rb
@@ -56,6 +56,7 @@ module Aws
                 sleep(@refresh_timeout / 2.0)
               rescue Aws::SQS::Errors::MessageNotInflight => e
                 # Message has been deleted or otherwise released. We don't care!
+                break
               rescue => e
                 # If anything else goes wrong, we should log and break the loop.
                 @logger.error("Monitor process failed for message: #{message.id}. Error: #{e}")

--- a/lib/aws/rails/sqs_active_job/poller.rb
+++ b/lib/aws/rails/sqs_active_job/poller.rb
@@ -52,7 +52,7 @@ module Aws
             max_threads: @options[:threads],
             logger: @logger,
             max_queue: @options[:backpressure]
-          }, refresh_visibility=@options[:refresh_visibility])
+          }, refresh_timeout = @options[:refresh_timeout])
 
           poll
         rescue Interrupt
@@ -116,7 +116,7 @@ module Aws
             opts.on("-t", "--threads INTEGER", Integer, "The maximum number of worker threads to create.  Defaults to 2x the number of processors available on this system.") { |a| out[:threads] = a }
             opts.on("-b", "--backpressure INTEGER", Integer, "The maximum number of messages to have waiting in the Executor queue. This should be a low, but non zero number.  Messages in the Executor queue cannot be picked up by other processes and will slow down shutdown.") { |a| out[:backpressure] = a }
             opts.on("-m", "--max_messages INTEGER", Integer, "Max number of messages to receive in a batch from SQS.") { |a| out[:max_messages] = a }
-            opts.on("-r", "--refresh_visibility", Integer, "Enables message visibility refresh, Value is timeout in seconds.") { |a| out[:refresh_visibility] = a }
+            opts.on("-r", "--refresh_timeout", Integer, "Enables message visibility refresh, Refresh timeout is in seconds.") { |a| out[:refresh_timeout] = a }
             opts.on("-v", "--visibility_timeout INTEGER", Integer, "The visibility timeout is the number of seconds that a message will not be processable by any other consumers. You should set this value to be longer than your expected job runtime to prevent other processes from picking up an running job.  See the SQS Visibility Timeout Documentation at https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html.") { |a| out[:visibility_timeout] = a }
             opts.on("-s", "--shutdown_timeout INTEGER", Integer, "The amount of time to wait for a clean shutdown.  Jobs that are unable to complete in this time will not be deleted from the SQS queue and will be retryable after the visibility timeout.") { |a| out[:shutdown_timeout] = a }
           }

--- a/lib/aws/rails/sqs_active_job/poller.rb
+++ b/lib/aws/rails/sqs_active_job/poller.rb
@@ -48,12 +48,12 @@ module Aws
 
           Signal.trap('INT') { raise Interrupt }
           Signal.trap('TERM') { raise Interrupt }
-          @executor = Executor.new({
+          @executor = Executor.new(
             max_threads: @options[:threads],
             logger: @logger,
-            max_queue: @options[:backpressure]
-            visibility_refresh: @options[:visibility_refresh])
-          })
+            max_queue: @options[:backpressure],
+            visibility_refresh: @options[:visibility_refresh]
+          )
 
           poll
         rescue Interrupt

--- a/lib/aws/rails/sqs_active_job/poller.rb
+++ b/lib/aws/rails/sqs_active_job/poller.rb
@@ -48,7 +48,11 @@ module Aws
 
           Signal.trap('INT') { raise Interrupt }
           Signal.trap('TERM') { raise Interrupt }
-          @executor = Executor.new(max_threads: @options[:threads], logger: @logger, max_queue: @options[:backpressure])
+          @executor = Executor.new({
+            max_threads: @options[:threads],
+            logger: @logger,
+            max_queue: @options[:backpressure]
+          }, refresh_visibility=@options[:refresh_visibility])
 
           poll
         rescue Interrupt
@@ -112,6 +116,7 @@ module Aws
             opts.on("-t", "--threads INTEGER", Integer, "The maximum number of worker threads to create.  Defaults to 2x the number of processors available on this system.") { |a| out[:threads] = a }
             opts.on("-b", "--backpressure INTEGER", Integer, "The maximum number of messages to have waiting in the Executor queue. This should be a low, but non zero number.  Messages in the Executor queue cannot be picked up by other processes and will slow down shutdown.") { |a| out[:backpressure] = a }
             opts.on("-m", "--max_messages INTEGER", Integer, "Max number of messages to receive in a batch from SQS.") { |a| out[:max_messages] = a }
+            opts.on("-r", "--refresh_visibility", Integer, "Enables message visibility refresh, Value is timeout in seconds.") { |a| out[:refresh_visibility] = a }
             opts.on("-v", "--visibility_timeout INTEGER", Integer, "The visibility timeout is the number of seconds that a message will not be processable by any other consumers. You should set this value to be longer than your expected job runtime to prevent other processes from picking up an running job.  See the SQS Visibility Timeout Documentation at https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html.") { |a| out[:visibility_timeout] = a }
             opts.on("-s", "--shutdown_timeout INTEGER", Integer, "The amount of time to wait for a clean shutdown.  Jobs that are unable to complete in this time will not be deleted from the SQS queue and will be retryable after the visibility timeout.") { |a| out[:shutdown_timeout] = a }
           }

--- a/lib/aws/rails/sqs_active_job/poller.rb
+++ b/lib/aws/rails/sqs_active_job/poller.rb
@@ -52,7 +52,8 @@ module Aws
             max_threads: @options[:threads],
             logger: @logger,
             max_queue: @options[:backpressure]
-          }, refresh_timeout = @options[:refresh_timeout])
+            visibility_refresh: @options[:visibility_refresh])
+          })
 
           poll
         rescue Interrupt
@@ -116,7 +117,7 @@ module Aws
             opts.on("-t", "--threads INTEGER", Integer, "The maximum number of worker threads to create.  Defaults to 2x the number of processors available on this system.") { |a| out[:threads] = a }
             opts.on("-b", "--backpressure INTEGER", Integer, "The maximum number of messages to have waiting in the Executor queue. This should be a low, but non zero number.  Messages in the Executor queue cannot be picked up by other processes and will slow down shutdown.") { |a| out[:backpressure] = a }
             opts.on("-m", "--max_messages INTEGER", Integer, "Max number of messages to receive in a batch from SQS.") { |a| out[:max_messages] = a }
-            opts.on("-r", "--refresh_timeout", Integer, "Enables message visibility refresh, Refresh timeout is in seconds.") { |a| out[:refresh_timeout] = a }
+            opts.on("-r", "--visibility_refresh", Integer, "Enables message visibility refresh, Value is in seconds.") { |a| out[:visibility_refresh] = a }
             opts.on("-v", "--visibility_timeout INTEGER", Integer, "The visibility timeout is the number of seconds that a message will not be processable by any other consumers. You should set this value to be longer than your expected job runtime to prevent other processes from picking up an running job.  See the SQS Visibility Timeout Documentation at https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html.") { |a| out[:visibility_timeout] = a }
             opts.on("-s", "--shutdown_timeout INTEGER", Integer, "The amount of time to wait for a clean shutdown.  Jobs that are unable to complete in this time will not be deleted from the SQS queue and will be retryable after the visibility timeout.") { |a| out[:shutdown_timeout] = a }
           }


### PR DESCRIPTION
*Description of changes:*

This PR will enable the auto-refresh of the visibility timeout of active messages.

This will allow users to use much lower default visibility timeouts, which will ensure messages can be returned to the queue promptly after a job fails, etc.

NOTE: I didn't do the work of adding automated tests yet, will do so if the work is acceptable.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
