### PR TITLE
Support `Mail::Message#smtp_envelope_from` and `_to`

### DIFF
--- a/lib/aws/rails/mailer.rb
+++ b/lib/aws/rails/mailer.rb
@@ -28,10 +28,8 @@ module Aws
         send_opts = {}
         send_opts[:raw_message] = {}
         send_opts[:raw_message][:data] = message.to_s
-
-        if message.respond_to?(:destinations)
-          send_opts[:destinations] = message.destinations
-        end
+        send_opts[:source] = message.smtp_envelope_from
+        send_opts[:destinations] = message.smtp_envelope_to
 
         @client.send_raw_email(send_opts).tap do |response|
           message.header[:ses_message_id] = response.message_id


### PR DESCRIPTION
SMTP allows sending mail using different sender and recipient addresses than those present in the `From`/`To`/`Cc`/etc. message header fields.

Use `Mail::Message#smtp_envelope_from` and `#smtp_envelope_to` to retrieve the `Source` and `Destination` parameters for `SendRawEmail`. If not specified explicitly, these addresses default to the values of the `Return-Path`/`Sender`/`From` and `To`/`Cc`/`Bcc` headers.

These methods were present in mail 2.5, the [oldest version supported by Rails 5.2](https://github.com/rails/rails/blob/5-2-stable/actionmailer/actionmailer.gemspec#L33), which is the oldest version supported by aws-sdk-rails.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
