### PR TITLE
Fix sesv2 from_email_address missing sender name

### DIFF
--- a/lib/aws/rails/sesv2_mailer.rb
+++ b/lib/aws/rails/sesv2_mailer.rb
@@ -27,7 +27,7 @@ module Aws
       def deliver!(message)
         params = {
           content: { raw: { data: message.to_s } },
-          from_email_address: message.smtp_envelope_from, # defaults to From header
+          from_email_address: from_email_address(message),
           # defaults to destinations (To,Cc,Bcc) - stick all on bcc to be delivered anyway
           destination: { bcc_addresses: message.smtp_envelope_to }
         }
@@ -39,6 +39,23 @@ module Aws
       # ActionMailer expects this method to be present and to return a hash.
       def settings
         {}
+      end
+
+      private
+
+      def from_email_address(message)
+        # from_address is an extension added to Main::Message in Rails6+
+        from_address = message.respond_to?(:from_address) && message.from_address
+
+        # We want to make sure the email is sent to smtp_envelope_from (defaults to From header, only address part),
+        # but message.from_address might include the sender name.
+        # e.g. from_address: 'Some Sender <some.sender@example.com>', smtp_envelope_from: 'some.sender@example.com'
+        # So use from_address only when the address part matches smtp_envelope_from, otherwise use smtp_envelope_from.
+        if from_address.to_s.include?(message.smtp_envelope_from)
+          from_address.to_s
+        else
+          message.smtp_envelope_from
+        end
       end
     end
   end

--- a/test/aws/rails/ses_mailer_test.rb
+++ b/test/aws/rails/ses_mailer_test.rb
@@ -22,11 +22,11 @@ module Aws
         TestMailer.deliverable(
           delivery_method: :ses,
           body: 'Hallo',
-          from: 'sender@example.com',
+          from: 'Sender <sender@example.com>',
           subject: 'This is a test',
-          to: 'recipient@example.com',
-          cc: 'recipient_cc@example.com',
-          bcc: 'recipient_bcc@example.com',
+          to: 'Recipient <recipient@example.com>',
+          cc: 'Recipient CC <recipient_cc@example.com>',
+          bcc: 'Recipient BCC <recipient_bcc@example.com>',
           headers: {
             'X-SES-CONFIGURATION-SET' => 'TestConfigSet',
             'X-SES-LIST-MANAGEMENT-OPTIONS' => 'contactListName; topic=topic'
@@ -63,7 +63,7 @@ module Aws
         end
 
         it 'delivers the message with SMTP envelope sender and recipient' do
-          message = sample_message
+          message = sample_message.message
           message.smtp_envelope_from = 'envelope-sender@example.com'
           message.smtp_envelope_to = 'envelope-recipient@example.com'
           mailer_data = mailer.deliver!(message).context.params


### PR DESCRIPTION
*Issue #97*

*Description of changes:*
Fix the issue reported in #97 for SESV2.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
