### PR TITLE
Fix detecting docker host

### DIFF
--- a/lib/aws/rails/middleware/ebs_sqs_active_job_middleware.rb
+++ b/lib/aws/rails/middleware/ebs_sqs_active_job_middleware.rb
@@ -89,7 +89,7 @@ module Aws
       end
 
       def default_gw_ips
-        default_gw_ips = []
+        default_gw_ips = ['172.17.0.1']
 
         if File.exist?('/proc/net/route')
           open('/proc/net/route').each_line do |line|

--- a/lib/aws/rails/middleware/ebs_sqs_active_job_middleware.rb
+++ b/lib/aws/rails/middleware/ebs_sqs_active_job_middleware.rb
@@ -94,6 +94,8 @@ module Aws
         if File.exist?('/proc/net/route')
           open('/proc/net/route').each_line do |line|
             fields = line.strip.split
+            next if fields.size != 11
+
             # Destination == 0.0.0.0 and Flags & RTF_GATEWAY != 0
             if fields[1] == '00000000' && (fields[3].hex & 0x2) != 0
               default_gw_ips << IPAddr.new_ntoh([fields[2].hex].pack('L')).to_s

--- a/lib/aws/rails/middleware/ebs_sqs_active_job_middleware.rb
+++ b/lib/aws/rails/middleware/ebs_sqs_active_job_middleware.rb
@@ -92,7 +92,7 @@ module Aws
         default_gw_ips = ['172.17.0.1']
 
         if File.exist?('/proc/net/route')
-          open('/proc/net/route').each_line do |line|
+          File.open('/proc/net/route').each_line do |line|
             fields = line.strip.split
             next if fields.size != 11
 

--- a/lib/aws/rails/middleware/ebs_sqs_active_job_middleware.rb
+++ b/lib/aws/rails/middleware/ebs_sqs_active_job_middleware.rb
@@ -81,11 +81,27 @@ module Aws
       end
 
       def sent_from_docker_host?(request)
-        app_runs_in_docker_container? && request.ip == '172.17.0.1'
+        app_runs_in_docker_container? && default_gw_ips.include?(request.ip)
       end
 
       def app_runs_in_docker_container?
         @app_runs_in_docker_container ||= `[ -f /proc/1/cgroup ] && cat /proc/1/cgroup` =~ /docker/
+      end
+
+      def default_gw_ips
+        default_gw_ips = []
+
+        if File.exist?('/proc/net/route')
+          open('/proc/net/route').each_line do |line|
+            fields = line.strip.split
+            # Destination == 0.0.0.0 and Flags & RTF_GATEWAY != 0
+            if fields[1] == '00000000' && (fields[3].hex & 0x2) != 0
+              default_gw_ips << IPAddr.new_ntoh([fields[2].hex].pack('L')).to_s
+            end
+          end
+        end
+
+        default_gw_ips
       end
     end
   end

--- a/test/aws/rails/middleware/ebs_sqs_active_job_middleware_test.rb
+++ b/test/aws/rails/middleware/ebs_sqs_active_job_middleware_test.rb
@@ -76,6 +76,46 @@ module Aws
         expect(response[0]).to eq(500)
       end
 
+      it 'successfully invokes job when docker default gateway ip is changed' do
+        mock_rack_env = create_mock_env('192.168.176.1', 'aws-sqsd/1.1', false)
+        test_middleware = EbsSqsActiveJobMiddleware.new(mock_rack_app)
+
+        proc_net_route = <<~CONTENT
+          Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT
+          eth0\t00000000\t01B0A8C0\t0003\t0\t0\t0\t00000000\t0\t0\t0
+          eth0\t00B0A8C0\t00000000\t0001\t0\t0\t0\t00F0FFFF\t0\t0\t0
+        CONTENT
+
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:open).and_call_original
+
+        expect(File).to receive(:exist?).with('/proc/net/route').and_return(true)
+        expect(File).to receive(:open).with('/proc/net/route').and_return(StringIO.new(proc_net_route))
+        expect(test_middleware).to receive(:app_runs_in_docker_container?).and_return(true)
+
+        response = test_middleware.call(mock_rack_env)
+
+        expect(response[0]).to eq(200)
+        expect(response[1]['Content-Type']).to eq('text/plain')
+        expect(response[2]).to eq(['Successfully ran job ElasticBeanstalkJob.'])
+      end
+
+      it 'successfully invokes job when /proc/net/route is not exist' do
+        mock_rack_env = create_mock_env('172.17.0.1', 'aws-sqsd/1.1', false)
+        test_middleware = EbsSqsActiveJobMiddleware.new(mock_rack_app)
+
+        allow(File).to receive(:exist?).and_call_original
+
+        expect(File).to receive(:exist?).with('/proc/net/route').and_return(false)
+        expect(test_middleware).to receive(:app_runs_in_docker_container?).and_return(true)
+
+        response = test_middleware.call(mock_rack_env)
+
+        expect(response[0]).to eq(200)
+        expect(response[1]['Content-Type']).to eq('text/plain')
+        expect(response[2]).to eq(['Successfully ran job ElasticBeanstalkJob.'])
+      end
+
       # Create a minimal mock Rack environment hash to test just what we need
       def create_mock_env(source_ip, user_agent, is_periodic_task = false)
         mock_env = {

--- a/test/aws/rails/middleware/ebs_sqs_active_job_middleware_test.rb
+++ b/test/aws/rails/middleware/ebs_sqs_active_job_middleware_test.rb
@@ -100,7 +100,7 @@ module Aws
         expect(response[2]).to eq(['Successfully ran job ElasticBeanstalkJob.'])
       end
 
-      it 'successfully invokes job when /proc/net/route is not exist' do
+      it 'successfully invokes job when /proc/net/route does not exist' do
         mock_rack_env = create_mock_env('172.17.0.1', 'aws-sqsd/1.1', false)
         test_middleware = EbsSqsActiveJobMiddleware.new(mock_rack_app)
 


### PR DESCRIPTION
*Description of changes:*

This PR will fix the method of detecting docker host's request IP.
In the Beanstalk docker environment, request IP of the docker host is changed as follows.

```shell
# instance A
$ ip route show default
default via 172.20.0.1 dev eth0
```

```shell
# instance B
$ ip route show default
default via 192.168.48.1 dev eth0
```

```shell
# instance C
$ ip route show default
default via 192.168.32.1 dev eth0
```

I tested this PR in Beanstalk docker environment.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
