### PR TITLE
Improve performance to_h method of Aws::Rails::SqsActiveJob::Configuration object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Improve to_h method's performance of Aws::Rails::SqsActiveJob::Configuration object
+
 3.9.1 (2023-12-19)
 ------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Feature - Improve to_h method's performance of Aws::Rails::SqsActiveJob::Configuration object
+* Issue - Improve `to_h` method's performance of `Aws::Rails::SqsActiveJob::Configuration`.
 
 3.9.1 (2023-12-19)
 ------------------

--- a/lib/aws/rails/sqs_active_job/configuration.rb
+++ b/lib/aws/rails/sqs_active_job/configuration.rb
@@ -126,7 +126,7 @@ module Aws
         def to_h
           h = {}
           instance_variables.each do |v|
-            v_sym = v.to_s.gsub('@', '').to_sym
+            v_sym = v.to_s.delete('@').to_sym
             val = instance_variable_get(v)
             h[v_sym] = val
           end


### PR DESCRIPTION
*Description of changes:*

Improve performance `to_h` method of `Aws::Rails::SqsActiveJob::Configuration` object.

When erase `@` of instance_variables, 
it could be use String#delete instead of String#gsub .

`delete` is more faster than `gsub` 
You can refer below benchmark.

```ruby
require 'benchmark/ips'

STRING = "@abcdefg".freeze

def gsub
  STRING.gsub('@', '').to_sym
end

def delete
  STRING.delete('@').to_sym
end

Benchmark.ips do |x|
  x.report('gsub') { gsub }
  x.report('delete') { delete }
  x.compare!
end
```

the result is

```
ruby 3.2.2 (2023-03-30 revision e51014f9c0) [x86_64-linux]
Warming up --------------------------------------
                gsub    81.596k i/100ms
              delete   320.575k i/100ms
Calculating -------------------------------------
                gsub      1.230M (±13.2%) i/s -      6.120M in   5.099980s
              delete      3.425M (±12.5%) i/s -     16.990M in   5.067744s

Comparison:
              delete:  3425068.2 i/s
                gsub:  1229521.8 i/s - 2.79x  slower
```


By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
