### PR TITLE
Support AJ 7.1 perform_all_later api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Support `enqueue_all` in the SQS ActiveJob adapter. 
+
 * Issue - Improve `to_h` method's performance of `Aws::Rails::SqsActiveJob::Configuration`.
 
 3.9.1 (2023-12-19)

--- a/lib/active_job/queue_adapters/amazon_sqs_adapter.rb
+++ b/lib/active_job/queue_adapters/amazon_sqs_adapter.rb
@@ -10,11 +10,7 @@ module ActiveJob
       end
 
       def enqueue_at(job, timestamp)
-        delay = (timestamp - Time.now.to_f).floor
-
-        delay = 0 if delay.negative?
-        raise ArgumentError, 'Unable to queue a job with a delay great than 15 minutes' if delay > 15.minutes
-
+        delay = Params.assured_delay_seconds(timestamp)
         _enqueue(job, nil, delay_seconds: delay)
       end
 

--- a/lib/active_job/queue_adapters/amazon_sqs_adapter.rb
+++ b/lib/active_job/queue_adapters/amazon_sqs_adapter.rb
@@ -14,6 +14,30 @@ module ActiveJob
         _enqueue(job, nil, delay_seconds: delay)
       end
 
+      def enqueue_all(jobs)
+        enqueued_count = 0
+        jobs.group_by(&:queue_name).each do |queue_name, same_queue_jobs|
+          queue_url = Aws::Rails::SqsActiveJob.config.queue_url_for(queue_name)
+          base_send_message_opts = { queue_url: queue_url }
+
+          same_queue_jobs.each_slice(10) do |chunk|
+            entries = chunk.map do |job|
+              entry = Params.new(job, nil).entry
+              entry[:id] = job.job_id
+              entry[:delay_seconds] = Params.assured_delay_seconds(job.scheduled_at) if job.scheduled_at
+              entry
+            end
+
+            send_message_opts = base_send_message_opts.deep_dup
+            send_message_opts[:entries] = entries
+
+            send_message_batch_result = Aws::Rails::SqsActiveJob.config.client.send_message_batch(send_message_opts)
+            enqueued_count += send_message_batch_result.successful.count
+          end
+        end
+        enqueued_count
+      end
+
       private
 
       def _enqueue(job, body = nil, send_message_opts = {})

--- a/lib/active_job/queue_adapters/amazon_sqs_adapter/params.rb
+++ b/lib/active_job/queue_adapters/amazon_sqs_adapter/params.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  module QueueAdapters
+    class AmazonSqsAdapter
+      # == build request parameter of Aws::SQS::Client
+      class Params
+        def initialize(job, body)
+          @job = job
+          @body = body || job.serialize
+        end
+
+        def queue_url
+          @queue_url ||= Aws::Rails::SqsActiveJob.config.queue_url_for(@job.queue_name)
+        end
+
+        def entry
+          if Aws::Rails::SqsActiveJob.fifo?(queue_url)
+            default_entry.merge(options_for_fifo)
+          else
+            default_entry
+          end
+        end
+
+        private
+
+        def default_entry
+          {
+            message_body: Aws::Json.dump(@body),
+            message_attributes: message_attributes
+          }
+        end
+
+        def message_attributes
+          {
+            'aws_sqs_active_job_class' => {
+              string_value: @job.class.to_s,
+              data_type: 'String'
+            },
+            'aws_sqs_active_job_version' => {
+              string_value: Aws::Rails::VERSION,
+              data_type: 'String'
+            }
+          }
+        end
+
+        def options_for_fifo
+          options = {}
+          options[:message_deduplication_id] =
+            Digest::SHA256.hexdigest(Aws::Json.dump(deduplication_body))
+
+          message_group_id = @job.message_group_id if @job.respond_to?(:message_group_id)
+          message_group_id ||= Aws::Rails::SqsActiveJob.config.message_group_id
+
+          options[:message_group_id] = message_group_id
+          options
+        end
+
+        def deduplication_body
+          ex_dedup_keys = @job.excluded_deduplication_keys if @job.respond_to?(:excluded_deduplication_keys)
+          ex_dedup_keys ||= Aws::Rails::SqsActiveJob.config.excluded_deduplication_keys
+
+          @body.except(*ex_dedup_keys)
+        end
+      end
+    end
+  end
+end

--- a/lib/active_job/queue_adapters/amazon_sqs_adapter/params.rb
+++ b/lib/active_job/queue_adapters/amazon_sqs_adapter/params.rb
@@ -5,6 +5,16 @@ module ActiveJob
     class AmazonSqsAdapter
       # == build request parameter of Aws::SQS::Client
       class Params
+        class << self
+          def assured_delay_seconds(timestamp)
+            delay = (timestamp - Time.now.to_f).floor
+            delay = 0 if delay.negative?
+            raise ArgumentError, 'Unable to queue a job with a delay great than 15 minutes' if delay > 15.minutes
+
+            delay
+          end
+        end
+
         def initialize(job, body)
           @job = job
           @body = body || job.serialize

--- a/lib/aws-sdk-rails.rb
+++ b/lib/aws-sdk-rails.rb
@@ -13,6 +13,7 @@ require_relative 'aws/rails/middleware/ebs_sqs_active_job_middleware'
 
 require_relative 'action_dispatch/session/dynamodb_store'
 require_relative 'active_job/queue_adapters/amazon_sqs_adapter'
+require_relative 'active_job/queue_adapters/amazon_sqs_adapter/params'
 require_relative 'active_job/queue_adapters/amazon_sqs_async_adapter'
 
 require_relative 'generators/aws_record/base'

--- a/test/active_job/queue_adapters/amazon_sqs_adapter/params_test.rb
+++ b/test/active_job/queue_adapters/amazon_sqs_adapter/params_test.rb
@@ -1,12 +1,32 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require 'timecop'
 
 module ActiveJob
   module QueueAdapters
     class AmazonSqsAdapter
       describe Params do
+        describe '.assured_delay_seconds' do
+          let(:now) { Time.now }
+
+          before { allow(Time).to receive(:now).and_return(now) }
+
+          it 'returns seconds from present' do
+            unix_time = (now + 15.minutes).to_f
+            expect(Params.assured_delay_seconds(unix_time)).to eq 900
+          end
+
+          it 'rounds up to zero' do
+            unix_time = (now - 1.second).to_f
+            expect(Params.assured_delay_seconds(unix_time)).to eq 0
+          end
+
+          it 'raise error when 15 minutes after present' do
+            unix_time = (now + 15.minutes + 1.second).to_f
+            expect { Params.assured_delay_seconds(unix_time) }.to raise_error ArgumentError
+          end
+        end
+
         describe '#queue_url' do
           let(:params) { Params.new(job, nil) }
           let(:job) { TestJob.new('a1', 'a2') }

--- a/test/active_job/queue_adapters/amazon_sqs_adapter/params_test.rb
+++ b/test/active_job/queue_adapters/amazon_sqs_adapter/params_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'timecop'
+
+module ActiveJob
+  module QueueAdapters
+    class AmazonSqsAdapter
+      describe Params do
+        describe '#queue_url' do
+          let(:params) { Params.new(job, nil) }
+          let(:job) { TestJob.new('a1', 'a2') }
+
+          it 'returns url of job queue' do
+            expect(params.queue_url).to eq 'https://queue-url'
+          end
+        end
+
+        describe '#entry' do
+          let(:params) { Params.new(job, nil) }
+          let(:job) { TestJob.new('a1', 'a2') }
+
+          it 'returns hash of core attributes' do
+            expect(params.entry).to include(
+              {
+                message_body: instance_of(String),
+                message_attributes: instance_of(Hash)
+              }
+            )
+          end
+
+          describe 'fifo queue' do
+            before do
+              allow(Aws::Rails::SqsActiveJob.config).to receive(:queue_url_for).and_return('https://queue-url.fifo')
+            end
+
+            it 'includes message_group_id and message_deduplication_id' do
+              expect(params.entry).to include(
+                {
+                  message_body: instance_of(String),
+                  message_attributes: instance_of(Hash),
+                  message_group_id: String,
+                  message_deduplication_id: String
+                }
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Rails 7.1 adds API for queuing multiple jobs simultaneously.](https://github.com/rails/rails/pull/46603)
To use this feature, we need to implement `#enqueue_all` method in job adapter.

references:
- https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessageBatch.html#API_SendMessageBatch_RequestSyntax
- https://github.com/aws/aws-sdk-ruby/blob/1544a183c0e78cf22fe1889805644d00880bfc4e/gems/aws-sdk-sqs/lib/aws-sdk-sqs/client.rb#L2277-L2376

close: #105 
