### PR TITLE
Add retry_standard_errors config for SQS ActiveJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Add `retry_standard_errors` (default `true`) in SQS ActiveJob and improve retry logic (#114).
+
 3.10.0 (2024-01-19)
 ------------------
 

--- a/lib/aws/rails/sqs_active_job/configuration.rb
+++ b/lib/aws/rails/sqs_active_job/configuration.rb
@@ -25,7 +25,7 @@ module Aws
         DEFAULTS = {
           max_messages: 10,
           shutdown_timeout: 15,
-          retry_standard_errors: true,
+          retry_standard_errors: true, # TODO: Remove in next MV
           queues: {},
           logger: ::Rails.logger,
           message_group_id: 'SqsActiveJobGroup',

--- a/lib/aws/rails/sqs_active_job/configuration.rb
+++ b/lib/aws/rails/sqs_active_job/configuration.rb
@@ -25,6 +25,7 @@ module Aws
         DEFAULTS = {
           max_messages: 10,
           shutdown_timeout: 15,
+          retry_standard_errors: true,
           queues: {},
           logger: ::Rails.logger,
           message_group_id: 'SqsActiveJobGroup',
@@ -63,6 +64,16 @@ module Aws
         #   for a clean shutdown.  Jobs that are unable to complete in this time
         #   will not be deleted from the SQS queue and will be retryable after
         #   the visibility timeout.
+        #
+        # @ option options [Boolean] :retry_standard_errors
+        #   If `true`, StandardErrors raised by ActiveJobs are left on the queue
+        #   and will be retried (pending the SQS Queue's redrive/DLQ/maximum receive settings).
+        #   This behavior overrides the standard Rails ActiveJob
+        #   [Retry/Discard for failed jobs](https://guides.rubyonrails.org/active_job_basics.html#retrying-or-discarding-failed-jobs)
+        #   behavior.  When set to `true` the retries provided by this will be
+        #   on top of any retries configured on the job with `retry_on`.
+        #   When `false`, retry behavior is fully configured
+        #   through `retry_on`/`discard_on` on the ActiveJobs.
         #
         # @option options [ActiveSupport::Logger] :logger Logger to use
         #   for the poller.

--- a/lib/aws/rails/sqs_active_job/executor.rb
+++ b/lib/aws/rails/sqs_active_job/executor.rb
@@ -41,7 +41,6 @@ module Aws
               else
                 message.delete
               end
-
             end
           end
         end

--- a/lib/aws/rails/sqs_active_job/job_runner.rb
+++ b/lib/aws/rails/sqs_active_job/job_runner.rb
@@ -15,6 +15,11 @@ module Aws
         def run
           ActiveJob::Base.execute @job_data
         end
+
+        def exception_executions?
+          @job_data['exception_executions'] &&
+            !@job_data['exception_executions'].empty?
+        end
       end
     end
   end

--- a/lib/aws/rails/sqs_active_job/poller.rb
+++ b/lib/aws/rails/sqs_active_job/poller.rb
@@ -105,6 +105,7 @@ module Aws
           require File.expand_path('config/environment.rb')
         end
 
+        # rubocop:disable Metrics
         def parse_args(argv)
           out = {}
           parser = ::OptionParser.new do |opts|
@@ -134,7 +135,7 @@ module Aws
               out[:shutdown_timeout] = a
             end
             opts.on('--[no-]retry_standard_errors [FLAG]', TrueClass,
-              'When set, retry all StandardErrors (leaving failed messages on the SQS Queue). These retries are ON TOP of standard Rails ActiveJob retries set by retry_on in the ActiveJob.') do |a|
+                    'When set, retry all StandardErrors (leaving failed messages on the SQS Queue). These retries are ON TOP of standard Rails ActiveJob retries set by retry_on in the ActiveJob.') do |a|
               out[:retry_standard_errors] = a.nil? ? true : a
             end
           end
@@ -148,6 +149,7 @@ module Aws
           parser.parse(argv)
           out
         end
+        # rubocop:enable Metrics
 
         def validate_config
           raise ArgumentError, 'You must specify the name of the queue to process jobs from' unless @options[:queue]

--- a/sample_app/Gemfile
+++ b/sample_app/Gemfile
@@ -15,7 +15,7 @@ gem "sprockets-rails"
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3', '~> 1.4'
 # Use Puma as the app server
-gem 'puma', '~> 5.0'
+gem 'puma', '~> 6.0'
 # Use SCSS for stylesheets
 gem 'sass-rails', '>= 6'
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker

--- a/sample_app/app/jobs/hello_job.rb
+++ b/sample_app/app/jobs/hello_job.rb
@@ -3,10 +3,15 @@ class HelloJob < ApplicationJob
 
   class NameException < StandardError; end
 
+  class SkipException < StandardError; end
+
   retry_on NameException
+  discard_on SkipException
 
   def perform(name)
     raise NameException if name == "error"
+    raise SkipException if name == "skip"
+    raise StandardError if name == "StandardError"
 
     puts "Hello from our job: #{name}"
   end

--- a/sample_app/app/jobs/hello_job.rb
+++ b/sample_app/app/jobs/hello_job.rb
@@ -1,7 +1,13 @@
 class HelloJob < ApplicationJob
   queue_as :default
 
+  class NameException < StandardError; end
+
+  retry_on NameException
+
   def perform(name)
+    raise NameException if name == "error"
+
     puts "Hello from our job: #{name}"
   end
 end

--- a/sample_app/config/aws_sqs_active_job.yml
+++ b/sample_app/config/aws_sqs_active_job.yml
@@ -1,3 +1,4 @@
 queues:
-  default: 'https://sqs.us-east-1.amazonaws.com/655347895545/ActiveJobDefault'
+  default: <%= ENV['AWS_ACTIVE_JOB_QUEUE_URL'] %>
 shutdown_timeout: 10
+retry_standard_errors: true

--- a/test/aws/rails/sqs_active_job/executor_test.rb
+++ b/test/aws/rails/sqs_active_job/executor_test.rb
@@ -34,12 +34,24 @@ module Aws
             executor.shutdown # give the job a chance to run
           end
 
-          it 'does not delete the message on exception' do
+          it 'deletes the message on exception' do
             expect(JobRunner).to receive(:new).and_return(runner)
             expect(runner).to receive(:run).and_raise StandardError
-            expect(msg).not_to receive(:delete)
+            expect(msg).to receive(:delete)
             executor.execute(msg)
             executor.shutdown # give the job a chance to run
+          end
+
+          describe 'retry_standard_errors' do
+            let(:executor) { Executor.new(retry_standard_errors: true) }
+
+            it 'does not delete the message on exception' do
+              expect(JobRunner).to receive(:new).and_return(runner)
+              expect(runner).to receive(:run).and_raise StandardError
+              expect(msg).not_to receive(:delete)
+              executor.execute(msg)
+              executor.shutdown # give the job a chance to run
+            end
           end
         end
 


### PR DESCRIPTION
*Issue #, if available:* 
Fixes #114 

*Description of changes:*
Adds configuration to change the behavior of SQS ActiveJob's handling of retries for exceptions from ActiveJobs.  

The existing behavior does not follow the [https://guides.rubyonrails.org/active_job_basics.html#retrying-or-discarding-failed-jobs](Rails ActiveJob) retry/discard behavior which notes that failed jobs are not retried unless the jobs are configured otherwise.

To avoid this being a breaking change for existing users, the flag currently defaults to `true` (preserving the existing behavior). 

Pending review, I will update the Readme to describe in more detail the interaction of SQS retry and Rails ActiveJob retries.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
