### PR TITLE
Add docker with cgroup2 detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased Changes
 ------------------
+* Issue - Fix `EbsSqsActiveJobMiddleware` to detect Docker container with cgroup2. (#116).
 
 3.11.0 (2024-03-01)
 ------------------

--- a/lib/aws/rails/middleware/ebs_sqs_active_job_middleware.rb
+++ b/lib/aws/rails/middleware/ebs_sqs_active_job_middleware.rb
@@ -85,14 +85,14 @@ module Aws
       end
 
       def app_runs_in_docker_container?
-        @app_runs_in_docker_container ||= in_docker_containr_with_cgroup1? || in_docker_containr_with_cgroup2?
+        @app_runs_in_docker_container ||= in_docker_container_with_cgroup1? || in_docker_container_with_cgroup2?
       end
 
-      def in_docker_containr_with_cgroup1?
+      def in_docker_container_with_cgroup1?
         File.exist?('/proc/1/cgroup') && File.read('/proc/1/cgroup') =~ %r{/docker/}
       end
 
-      def in_docker_containr_with_cgroup2?
+      def in_docker_container_with_cgroup2?
         File.exist?('/proc/self/mountinfo') && File.read('/proc/self/mountinfo') =~ %r{/docker/containers/}
       end
 

--- a/lib/aws/rails/middleware/ebs_sqs_active_job_middleware.rb
+++ b/lib/aws/rails/middleware/ebs_sqs_active_job_middleware.rb
@@ -93,7 +93,7 @@ module Aws
       end
 
       def in_docker_containr_with_cgroup2?
-        File.exist?('/proc/1/mountinfo') && File.read('/proc/1/mountinfo') =~ %r{/docker/containers/}
+        File.exist?('/proc/self/mountinfo') && File.read('/proc/self/mountinfo') =~ %r{/docker/containers/}
       end
 
       def default_gw_ips

--- a/lib/aws/rails/middleware/ebs_sqs_active_job_middleware.rb
+++ b/lib/aws/rails/middleware/ebs_sqs_active_job_middleware.rb
@@ -85,7 +85,15 @@ module Aws
       end
 
       def app_runs_in_docker_container?
-        @app_runs_in_docker_container ||= `[ -f /proc/1/cgroup ] && cat /proc/1/cgroup` =~ /docker/
+        @app_runs_in_docker_container ||= in_docker_containr_with_cgroup1? || in_docker_containr_with_cgroup2?
+      end
+
+      def in_docker_containr_with_cgroup1?
+        File.exist?('/proc/1/cgroup') && File.read('/proc/1/cgroup') =~ %r{/docker/}
+      end
+
+      def in_docker_containr_with_cgroup2?
+        File.exist?('/proc/1/mountinfo') && File.read('/proc/1/mountinfo') =~ %r{/docker/containers/}
       end
 
       def default_gw_ips

--- a/test/aws/rails/middleware/ebs_sqs_active_job_middleware_test.rb
+++ b/test/aws/rails/middleware/ebs_sqs_active_job_middleware_test.rb
@@ -151,7 +151,7 @@ module Aws
           0::/
         CONTENT
 
-        proc_1_mountinfo = <<~CONTENT
+        proc_self_mountinfo = <<~CONTENT
           355 354 0:21 / /sys/fs/cgroup ro,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw,nsdelegate
           356 352 0:74 / /dev/mqueue rw,nosuid,nodev,noexec,relatime - mqueue mqueue rw
           357 352 0:79 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs shm rw,size=65536k
@@ -166,8 +166,8 @@ module Aws
 
         expect(File).to receive(:exist?).with('/proc/1/cgroup').and_return(true)
         expect(File).to receive(:read).with('/proc/1/cgroup').and_return(proc_1_cgroup)
-        expect(File).to receive(:exist?).with('/proc/1/mountinfo').and_return(true)
-        expect(File).to receive(:read).with('/proc/1/mountinfo').and_return(proc_1_mountinfo)
+        expect(File).to receive(:exist?).with('/proc/self/mountinfo').and_return(true)
+        expect(File).to receive(:read).with('/proc/self/mountinfo').and_return(proc_self_mountinfo)
 
         response = test_middleware.call(mock_rack_env)
 


### PR DESCRIPTION
*Issue #, if available:*
* Amazon Linux 2023 runs docker in cgroup2, so EbsSqsActiveJobMiddleware#app_runs_in_docker_container? which only assumes cgroup1 will return false.

*Description of changes:*
1. Refactored the code of detecting cgroup1 using external commands and add its tests.
2. Add the code  of detecting cgroup2 and add its tests.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
