### PR TITLE
Update CI to drop Ruby 2.3 and 2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, jruby-9.1, jruby-9.2, jruby-9.3, jruby-9.4]
+        ruby: [2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, jruby-9.2, jruby-9.3, jruby-9.4]
         gemfile: [rails-5.2.gemfile, rails-6.0.gemfile, rails-6.1.gemfile, rails-7.0.gemfile, rails-main.gemfile]
 
         exclude:
@@ -30,34 +30,6 @@ jobs:
             ruby: 3.3
           - gemfile: rails-5.2.gemfile
             ruby: jruby-9.4
-
-          # Rails 6 requires Ruby >= 2.5
-          - gemfile: rails-6.0.gemfile
-            ruby: 2.3
-          - gemfile: rails-6.1.gemfile
-            ruby: 2.3
-          - gemfile: rails-7.0.gemfile
-            ruby: 2.3
-          - gemfile: rails-main.gemfile
-            ruby: 2.3
-
-          - gemfile: rails-6.0.gemfile
-            ruby: 2.4
-          - gemfile: rails-6.1.gemfile
-            ruby: 2.4
-          - gemfile: rails-7.0.gemfile
-            ruby: 2.4
-          - gemfile: rails-main.gemfile
-            ruby: 2.4
-
-          - gemfile: rails-6.0.gemfile
-            ruby: jruby-9.1
-          - gemfile: rails-6.1.gemfile
-            ruby: jruby-9.1
-          - gemfile: rails-7.0.gemfile
-            ruby: jruby-9.1
-          - gemfile: rails-main.gemfile
-            ruby: jruby-9.1
 
           # Rails 7 requires Ruby >= 2.7
           - gemfile: rails-7.0.gemfile
@@ -104,10 +76,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Ruby 3.2
+      - name: Set up Ruby 3.3
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.3
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Dropping support for Ruby 2.3, Ruby 2.4 and Jruby 9.1 based on the V3 SDK

---
By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
