### PR TITLE
No longer rely on caller_runs for backpressure in sqs active job executor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       AWS_REGION: us-east-1
       AWS_ACCESS_KEY_ID: dummy
       AWS_SECRET_ACCESS_KEY: dummy
-      AWS_SERVICE_ENDPOINT: http://localhost:8000
+      AWS_ENDPOINT_URL: http://localhost:8000
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - No longer rely on caller_runs for backpressure in sqs active job executor (#123).
+
 3.12.0 (2024-04-02)
 ------------------
 * Feature - Drop support for Ruby 2.3 and Ruby 2.4 (#117).

--- a/lib/active_job/queue_adapters/amazon_sqs_async_adapter.rb
+++ b/lib/active_job/queue_adapters/amazon_sqs_async_adapter.rb
@@ -20,13 +20,13 @@ module ActiveJob
         # FIFO jobs must be queued in order, so do not queue async
         queue_url = Aws::Rails::SqsActiveJob.config.queue_url_for(job.queue_name)
         if Aws::Rails::SqsActiveJob.fifo?(queue_url)
-          super(job, body, send_message_opts)
+          super
         else
           # Serialize is called here because the job’s locale needs to be
           # determined in this thread and not in some other thread.
           body = job.serialize
           Concurrent::Promises
-            .future { super(job, body, send_message_opts) }
+            .future { super }
             .rescue do |e|
               Rails.logger.error "Failed to queue job #{job}. Reason: #{e}"
               error_handler = Aws::Rails::SqsActiveJob.config.async_queue_error_handler

--- a/lib/aws/rails/sqs_active_job/executor.rb
+++ b/lib/aws/rails/sqs_active_job/executor.rb
@@ -23,8 +23,7 @@ module Aws
         end
 
         def execute(message)
-          begin
-            @executor.post(message) do |message|
+          @executor.post(message) do |message|
             job = JobRunner.new(message)
             @logger.info("Running job: #{job.id}[#{job.class_name}]")
             job.run
@@ -44,15 +43,14 @@ module Aws
             else
               message.delete
             end
-            ensure
-              @task_complete.set
-            end
-          rescue Concurrent::RejectedExecutionError
-            # no capacity, wait for a task to complete
-            @task_complete.reset
-            @task_complete.wait
-            retry
+          ensure
+            @task_complete.set
           end
+        rescue Concurrent::RejectedExecutionError
+          # no capacity, wait for a task to complete
+          @task_complete.reset
+          @task_complete.wait
+          retry
         end
 
         def shutdown(timeout = nil)

--- a/sample_app/bin/start_server
+++ b/sample_app/bin/start_server
@@ -6,8 +6,8 @@ if [ -e /workspace/sample_app/tmp/pids/*.pid ]; then rm /workspace/sample_app/tm
 
 bundle exec rails db:prepare
 
-aws sqs --endpoint $AWS_SERVICE_ENDPOINT create-queue --queue-name async-job-queue --no-cli-pager
-aws ses --endpoint $AWS_SERVICE_ENDPOINT verify-email-identity --email $ACTION_MAILER_EMAIL
+aws sqs --endpoint $AWS_ENDPOINT_URL create-queue --queue-name async-job-queue --no-cli-pager
+aws ses --endpoint $AWS_ENDPOINT_URL verify-email-identity --email $ACTION_MAILER_EMAIL
 
 bin/rails runner Aws::SessionStore::DynamoDB::Table.create_table
 

--- a/sample_app/config/initializers/aws.rb
+++ b/sample_app/config/initializers/aws.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-if ENV['AWS_SERVICE_ENDPOINT']
-  Aws.config.update(
-    endpoint: ENV['AWS_SERVICE_ENDPOINT'],
-  )
-end

--- a/sample_app/config/initializers/aws.rb
+++ b/sample_app/config/initializers/aws.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
-Aws.config.update(
-  endpoint: ENV['AWS_SERVICE_ENDPOINT'],
-)
+if ENV['AWS_SERVICE_ENDPOINT']
+  Aws.config.update(
+    endpoint: ENV['AWS_SERVICE_ENDPOINT'],
+  )
+end

--- a/sample_app/docker-compose.yml
+++ b/sample_app/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: ./Dockerfile
     command: ["bundle", "exec", "rails", "s", "-b", "0.0.0.0"]
     environment:
-      AWS_SERVICE_ENDPOINT: http://localstack:4566
+      AWS_ENDPOINT_URL: http://localstack:4566
       AWS_REGION: us-east-1
       AWS_ACCESS_KEY_ID: dummy
       AWS_SECRET_ACCESS_KEY: dummy
@@ -28,7 +28,7 @@ services:
       dockerfile: ./Dockerfile
     command: ["bundle", "exec", "aws_sqs_active_job", "--queue", "default"]
     environment:
-      AWS_SERVICE_ENDPOINT: http://localstack:4566
+      AWS_ENDPOINT_URL: http://localstack:4566
       AWS_REGION: us-east-1
       AWS_ACCESS_KEY_ID: dummy
       AWS_SECRET_ACCESS_KEY: dummy


### PR DESCRIPTION
Changes the `fallback_policy` on the executor to `:abort` instead of using `caller_runs`.  This will raise an `Concurrent::RejectedExecutionError` when posting to the executor when it does not have capacity.  It then uses a [Concurrent:Event](https://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent/Event.html) to block the calling thread until the next task completes.

*Issue #, if available:*
Fixes #123 

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
