### PR TITLE
Use Concurrent.available_processor_count to set default thread pool max threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased Changes
 ------------------
 
+* Issue - Use `Concurrent.available_processor_count` to set default thread pool max threads (#125).
 * Issue - No longer rely on caller_runs for backpressure in sqs active job executor (#123).
 
 3.12.0 (2024-04-02)

--- a/aws-sdk-rails.gemspec
+++ b/aws-sdk-rails.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('aws-sdk-sqs', '~> 1', '>= 1.56.0') # for ActiveJob
 
   spec.add_dependency('aws-sessionstore-dynamodb', '~> 2') # includes DynamoDB
-  spec.add_dependency('concurrent-ruby', '~> 1') # Utilities for concurrent processing
+  spec.add_dependency('concurrent-ruby', '>= 1.3.1') # Utilities for concurrent processing
   spec.add_dependency('railties', '>= 5.2.0') # encrypted credentials
   spec.add_development_dependency('rails')
 

--- a/lib/aws/rails/sqs_active_job/executor.rb
+++ b/lib/aws/rails/sqs_active_job/executor.rb
@@ -9,7 +9,7 @@ module Aws
       class Executor
         DEFAULTS = {
           min_threads: 0,
-          max_threads: Concurrent.processor_count,
+          max_threads: Concurrent.available_processor_count.to_i,
           auto_terminate: true,
           idletime: 60, # 1 minute
           fallback_policy: :abort # Concurrent::RejectedExecutionError must be handled

--- a/lib/aws/rails/sqs_active_job/executor.rb
+++ b/lib/aws/rails/sqs_active_job/executor.rb
@@ -9,7 +9,7 @@ module Aws
       class Executor
         DEFAULTS = {
           min_threads: 0,
-          max_threads: Concurrent.available_processor_count.to_i,
+          max_threads: Integer(Concurrent.available_processor_count || Concurrent.processor_count),
           auto_terminate: true,
           idletime: 60, # 1 minute
           fallback_policy: :abort # Concurrent::RejectedExecutionError must be handled

--- a/sample_app/Gemfile.lock
+++ b/sample_app/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       aws-sdk-sesv2 (~> 1, >= 1.34.0)
       aws-sdk-sqs (~> 1, >= 1.56.0)
       aws-sessionstore-dynamodb (~> 2)
-      concurrent-ruby (~> 1)
+      concurrent-ruby (>= 1.3.1)
       railties (>= 5.2.0)
 
 GEM


### PR DESCRIPTION
Use Concurrent.available_processor_count to set default thread pool max threads

*Issue #, if available:*
Fixes #125 



By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
