### PR TITLE
Deprecate :amazon as a config option for sqs active job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: bundle install --gemfile=gemfiles/${{ matrix.gemfile }}
 
       - name: Test
-        run: BUNDLE_GEMFILE=gemfiles/${{ matrix.gemfile }} bundle exec rspec --format documentation
+        run: BUNDLE_GEMFILE=gemfiles/${{ matrix.gemfile }} bundle exec rspec
 
   rubocop:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: bundle install --gemfile=gemfiles/${{ matrix.gemfile }}
 
       - name: Test
-        run: BUNDLE_GEMFILE=gemfiles/${{ matrix.gemfile }} bundle exec rspec
+        run: BUNDLE_GEMFILE=gemfiles/${{ matrix.gemfile }} bundle exec rspec --format documentation
 
   rubocop:
     runs-on: ubuntu-latest

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -75,7 +75,7 @@ Style/Documentation:
   Exclude:
     - 'spec/**/*'
     - 'test/**/*'
-    - 'lib/active_job/queue_adapters/amazon_sqs_adapter.rb'
+    - 'lib/active_job/queue_adapters/sqs_adapter.rb'
     - 'lib/aws/rails/notifications.rb'
     - 'lib/aws/rails/sqs_active_job/configuration.rb'
     - 'lib/aws/rails/sqs_active_job/job_runner.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Do not allow `:amazon`, `amazon_sqs`, or `amazon_sqs_async` for SQS active job configuration. Instead use `:sqs` and `:sqs_async`.
+
 3.13.0 (2024-06-06)
 ------------------
 
@@ -92,7 +94,7 @@ Unreleased Changes
 3.4.0 (2020-12-07)
 ------------------
 
-* Feature - Add a non-blocking async ActiveJob adapter: `:sqs_async`.
+* Feature - Add a non-blocking async ActiveJob adapter: `:amazon_sqs_async`.
 
 * Feature - Add a lambda handler for processing active jobs from an SQS trigger.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ Unreleased Changes
 3.4.0 (2020-12-07)
 ------------------
 
-* Feature - Add a non-blocking async ActiveJob adapter: `:amazon_sqs_async`.
+* Feature - Add a non-blocking async ActiveJob adapter: `:sqs_async`.
 
 * Feature - Add a lambda handler for processing active jobs from an SQS trigger.
 

--- a/README.md
+++ b/README.md
@@ -248,12 +248,9 @@ This package provides a lightweight, high performance SQS backend
 for [ActiveJob](https://guides.rubyonrails.org/active_job_basics.html).  
 
 To use AWS SQS ActiveJob as your queuing backend, simply set the `active_job.queue_adapter`
-to `:amazon` or `:amazon_sqs` (note, `:amazon` has been used for a number of
- other Amazon rails adapters such as ActiveStorage, so has been
- carried forward as convention here).  For details on setting the
- queuing backend see:
-[ActiveJob: Setting the Backend](https://guides.rubyonrails.org/active_job_basics.html#setting-the-backend).
-To use the non-blocking (async) adapter set `active_job.queue_adapter` to `:amazon_sqs_async`.  If you have
+to `:sqs` For details on setting the queuing backend see: [ActiveJob: Setting the Backend](https://guides.rubyonrails.org/active_job_basics.html#setting-the-backend).
+
+To use the non-blocking (async) adapter set `active_job.queue_adapter` to `:sqs_async`.  If you have
 a lot of jobs to queue or you need to avoid the extra latency from an SQS call in your request then consider
 using the async adapter.  However, you may also want to configure a `async_queue_error_handler` to
 handle errors that may occur when queuing jobs.  See the
@@ -265,15 +262,15 @@ for documentation.
 # config/application.rb
 module YourApp
   class Application < Rails::Application
-    config.active_job.queue_adapter = :amazon_sqs # note: can use either :amazon or :amazon_sqs
+    config.active_job.queue_adapter = :sqs
     # To use the non-blocking async adapter:
-    # config.active_job.queue_adapter = :amazon_sqs_async
+    # config.active_job.queue_adapter = :sqs_async
   end
 end
 
 # Or to set the adapter for a single job:
 class YourJob < ApplicationJob
-  self.queue_adapter = :amazon_sqs
+  self.queue_adapter = :sqs
   #....
 end
 ```
@@ -453,7 +450,7 @@ in your config.
 
 When using FIFO queues, jobs will NOT be processed concurrently by the poller
 to ensure the correct ordering.  Additionally, all jobs on a FIFO queue will be queued
-synchronously, even if you have configured the `amazon_sqs_async` adapter.
+synchronously, even if you have configured the `sqs_async` adapter.
 
 #### Message Deduplication ID
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rake/testtask'
+require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 
 $REPO_ROOT = File.dirname(__FILE__)
@@ -10,11 +10,7 @@ Dir.glob('**/*.rake').each do |task_file|
   load task_file
 end
 
-Rake::TestTask.new do |t|
-  t.libs << 'test'
-  t.pattern = 'test/**/*_test.rb'
-  t.warning = false
-end
+RSpec::Core::RakeTask.new(:test)
 
 RuboCop::RakeTask.new
 

--- a/lib/active_job/queue_adapters/sqs_adapter.rb
+++ b/lib/active_job/queue_adapters/sqs_adapter.rb
@@ -4,7 +4,7 @@ require 'aws-sdk-sqs'
 
 module ActiveJob
   module QueueAdapters
-    class AmazonSqsAdapter
+    class SqsAdapter
       def enqueue(job)
         _enqueue(job)
       end
@@ -49,9 +49,5 @@ module ActiveJob
         Aws::Rails::SqsActiveJob.config.client.send_message(send_message_opts)
       end
     end
-
-    # create an alias to allow `:amazon` to be used as the adapter name
-    # `:amazon` is the convention used for ActionMailer and ActiveStorage
-    AmazonAdapter = AmazonSqsAdapter
   end
 end

--- a/lib/active_job/queue_adapters/sqs_adapter/params.rb
+++ b/lib/active_job/queue_adapters/sqs_adapter/params.rb
@@ -2,7 +2,7 @@
 
 module ActiveJob
   module QueueAdapters
-    class AmazonSqsAdapter
+    class SqsAdapter
       # == build request parameter of Aws::SQS::Client
       class Params
         class << self

--- a/lib/active_job/queue_adapters/sqs_async_adapter.rb
+++ b/lib/active_job/queue_adapters/sqs_async_adapter.rb
@@ -12,8 +12,8 @@ module ActiveJob
     #
     # To use this adapter, set up as:
     #
-    # config.active_job.queue_adapter = :amazon_sqs_async
-    class AmazonSqsAsyncAdapter < AmazonSqsAdapter
+    # config.active_job.queue_adapter = :sqs_async
+    class SqsAsyncAdapter < SqsAdapter
       private
 
       def _enqueue(job, body = nil, send_message_opts = {})

--- a/lib/aws-sdk-rails.rb
+++ b/lib/aws-sdk-rails.rb
@@ -12,9 +12,9 @@ require_relative 'aws/rails/sqs_active_job/lambda_handler'
 require_relative 'aws/rails/middleware/ebs_sqs_active_job_middleware'
 
 require_relative 'action_dispatch/session/dynamodb_store'
-require_relative 'active_job/queue_adapters/amazon_sqs_adapter'
-require_relative 'active_job/queue_adapters/amazon_sqs_adapter/params'
-require_relative 'active_job/queue_adapters/amazon_sqs_async_adapter'
+require_relative 'active_job/queue_adapters/sqs_adapter'
+require_relative 'active_job/queue_adapters/sqs_adapter/params'
+require_relative 'active_job/queue_adapters/sqs_async_adapter'
 
 require_relative 'generators/aws_record/base'
 

--- a/lib/aws/rails/sqs_active_job/configuration.rb
+++ b/lib/aws/rails/sqs_active_job/configuration.rb
@@ -90,7 +90,7 @@ module Aws
         # @option options [Callable] :async_queue_error_handler An error handler
         #   to be called when the async active job adapter experiances an error
         #   queueing a job.  Only applies when
-        #   +active_job.queue_adapter = :amazon_sqs_async+.  Called with:
+        #   +active_job.queue_adapter = :sqs_async+.  Called with:
         #   [error, job, job_options]
         #
         # @option options [SQS::Client] :client SQS Client to use. A default

--- a/sample_app/config/application.rb
+++ b/sample_app/config/application.rb
@@ -19,10 +19,10 @@ module SampleApp
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
-    # Use the :amazon_sqs_async (non blocking)
+    # Use the :sqs_async (non blocking)
     # adapter from the aws-sdk-rails package
     # To poll for and run jobs you'll need to start a worker process:
     # bundle exec aws_sqs_active_job --queue default
-    config.active_job.queue_adapter = :amazon_sqs_async
+    config.active_job.queue_adapter = :sqs_async
   end
 end

--- a/spec/active_job/queue_adapters/sqs_adapter/params_spec.rb
+++ b/spec/active_job/queue_adapters/sqs_adapter/params_spec.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 module ActiveJob
   module QueueAdapters
-    class AmazonSqsAdapter
+    class SqsAdapter
       describe Params do
         describe '.assured_delay_seconds' do
           let(:now) { Time.now }

--- a/spec/active_job/queue_adapters/sqs_adapter_spec.rb
+++ b/spec/active_job/queue_adapters/sqs_adapter_spec.rb
@@ -5,7 +5,7 @@ require_relative '../../aws/rails/sqs_active_job/test_job'
 
 module ActiveJob
   module QueueAdapters
-    describe AmazonSqsAdapter do
+    describe SqsAdapter do
       let(:client) { double('Client') }
       before do
         allow(Aws::Rails::SqsActiveJob.config).to receive(:client).and_return(client)

--- a/spec/active_job/queue_adapters/sqs_async_adapter_spec.rb
+++ b/spec/active_job/queue_adapters/sqs_async_adapter_spec.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class TestJob < ActiveJob::Base
-  self.queue_adapter = :amazon_sqs_async
+  self.queue_adapter = :sqs_async
   queue_as :default
 
   def perform(*args); end
@@ -11,7 +11,7 @@ end
 
 module ActiveJob
   module QueueAdapters
-    describe AmazonSqsAsyncAdapter do
+    describe SqsAsyncAdapter do
       let(:client) { double('Client') }
       before do
         allow(Aws::Rails::SqsActiveJob.config).to receive(:client).and_return(client)

--- a/spec/aws/rails/sqs_active_job/executor_spec.rb
+++ b/spec/aws/rails/sqs_active_job/executor_spec.rb
@@ -61,6 +61,7 @@ module Aws
             it 'waits for a tasks to complete before attempting to post new tasks' do
               task_complete_event = executor.instance_variable_get(:@task_complete)
               expect(JobRunner).to receive(:new).at_least(:once).and_return(runner)
+              expect(msg).to receive(:delete).twice
               allow(runner).to receive(:run) do
                 trigger.wait
               end

--- a/spec/aws/rails/sqs_active_job/executor_spec.rb
+++ b/spec/aws/rails/sqs_active_job/executor_spec.rb
@@ -59,6 +59,9 @@ module Aws
             let(:trigger) { Concurrent::Event.new }
 
             it 'waits for a tasks to complete before attempting to post new tasks' do
+              # JRuby has some issue with race condition in this test
+              skip if defined?(JRUBY_VERSION)
+
               task_complete_event = executor.instance_variable_get(:@task_complete)
               expect(JobRunner).to receive(:new).at_least(:once).and_return(runner)
               allow(msg).to receive(:delete)
@@ -67,7 +70,6 @@ module Aws
               end
               executor.execute(msg) # first message runs
               executor.execute(msg) # second message enters queue
-              sleep(3)
               expect(task_complete_event).to receive(:wait).at_least(:once) do
                 trigger.set # unblock the task
               end

--- a/spec/aws/rails/sqs_active_job/executor_spec.rb
+++ b/spec/aws/rails/sqs_active_job/executor_spec.rb
@@ -61,22 +61,16 @@ module Aws
             it 'waits for a tasks to complete before attempting to post new tasks' do
               task_complete_event = executor.instance_variable_get(:@task_complete)
               expect(JobRunner).to receive(:new).at_least(:once).and_return(runner)
-              expect(msg).to receive(:delete).twice
+              allow(msg).to receive(:delete)
               allow(runner).to receive(:run) do
-                puts 'waiting!'
+                sleep(1)
                 trigger.wait
-                puts 'done waiting!'
               end
-              puts 'execute once'
               executor.execute(msg) # first message runs
-              puts 'execute twice'
               executor.execute(msg) # second message enters queue
               expect(task_complete_event).to receive(:wait).at_least(:once) do
-                puts 'trigger set'
                 trigger.set # unblock the task
-                puts 'trigger reset'
               end
-              puts 'execute thrice'
               executor.execute(msg) # third message triggers wait
             end
           end

--- a/spec/aws/rails/sqs_active_job/executor_spec.rb
+++ b/spec/aws/rails/sqs_active_job/executor_spec.rb
@@ -63,11 +63,11 @@ module Aws
               expect(JobRunner).to receive(:new).at_least(:once).and_return(runner)
               allow(msg).to receive(:delete)
               allow(runner).to receive(:run) do
-                sleep(1)
                 trigger.wait
               end
               executor.execute(msg) # first message runs
               executor.execute(msg) # second message enters queue
+              sleep(1)
               expect(task_complete_event).to receive(:wait).at_least(:once) do
                 trigger.set # unblock the task
               end

--- a/spec/aws/rails/sqs_active_job/executor_spec.rb
+++ b/spec/aws/rails/sqs_active_job/executor_spec.rb
@@ -63,13 +63,20 @@ module Aws
               expect(JobRunner).to receive(:new).at_least(:once).and_return(runner)
               expect(msg).to receive(:delete).twice
               allow(runner).to receive(:run) do
+                puts 'waiting!'
                 trigger.wait
+                puts 'done waiting!'
               end
+              puts 'execute once'
               executor.execute(msg) # first message runs
+              puts 'execute twice'
               executor.execute(msg) # second message enters queue
               expect(task_complete_event).to receive(:wait).at_least(:once) do
+                puts 'trigger set'
                 trigger.set # unblock the task
+                puts 'trigger reset'
               end
+              puts 'execute thrice'
               executor.execute(msg) # third message triggers wait
             end
           end

--- a/spec/aws/rails/sqs_active_job/executor_spec.rb
+++ b/spec/aws/rails/sqs_active_job/executor_spec.rb
@@ -67,7 +67,7 @@ module Aws
               end
               executor.execute(msg) # first message runs
               executor.execute(msg) # second message enters queue
-              sleep(1)
+              sleep(3)
               expect(task_complete_event).to receive(:wait).at_least(:once) do
                 trigger.set # unblock the task
               end

--- a/spec/aws/rails/sqs_active_job/executor_spec.rb
+++ b/spec/aws/rails/sqs_active_job/executor_spec.rb
@@ -59,20 +59,17 @@ module Aws
             let(:trigger) { Concurrent::Event.new }
 
             it 'waits for a tasks to complete before attempting to post new tasks' do
-              # JRuby has some issue with race condition in this test
-              skip if defined?(JRUBY_VERSION)
-
               task_complete_event = executor.instance_variable_get(:@task_complete)
               expect(JobRunner).to receive(:new).at_least(:once).and_return(runner)
               allow(msg).to receive(:delete)
               allow(runner).to receive(:run) do
                 trigger.wait
               end
-              executor.execute(msg) # first message runs
-              executor.execute(msg) # second message enters queue
               expect(task_complete_event).to receive(:wait).at_least(:once) do
                 trigger.set # unblock the task
               end
+              executor.execute(msg) # first message runs
+              executor.execute(msg) # second message enters queue
               executor.execute(msg) # third message triggers wait
             end
           end

--- a/spec/aws/rails/sqs_active_job/test_job.rb
+++ b/spec/aws/rails/sqs_active_job/test_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TestJob < ActiveJob::Base
-  self.queue_adapter = :amazon_sqs
+  self.queue_adapter = :sqs
   queue_as :default
 
   def perform(arg1, arg2); end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -12,6 +12,6 @@ module Dummy
     config.eager_load = false
     config.require_master_key = true
 
-    config.active_job.queue_adapter = :amazon
+    config.active_job.queue_adapter = :sqs
   end
 end


### PR DESCRIPTION
Removes `:amazon` as an option, use `:sqs` instead (will be in the major version bump).