### PR TITLE
Validate ActionMailer config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Ensure `:ses` or `:sesv2` as ActionMailer configuration.
+
 3.13.0 (2024-06-06)
 ------------------
 


### PR DESCRIPTION
Ensures :ses or :sesv2 and no longer take an arbitrary config.