### PR TITLE
Consolidate the loading of modules related to AWS SQS ActiveJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Refactor the loading of the SQS ActiveJob adapter to be in `aws/rails/sqs_active_job`.
+
 4.0.1 (2024-07-18)
 ------------------
 

--- a/lib/aws-sdk-rails.rb
+++ b/lib/aws-sdk-rails.rb
@@ -5,17 +5,10 @@ require_relative 'aws/rails/sesv2_mailer'
 require_relative 'aws/rails/railtie'
 require_relative 'aws/rails/action_mailbox/engine'
 require_relative 'aws/rails/notifications'
-require_relative 'aws/rails/sqs_active_job/configuration'
-require_relative 'aws/rails/sqs_active_job/deduplication'
-require_relative 'aws/rails/sqs_active_job/executor'
-require_relative 'aws/rails/sqs_active_job/job_runner'
-require_relative 'aws/rails/sqs_active_job/lambda_handler'
+require_relative 'aws/rails/sqs_active_job'
 require_relative 'aws/rails/middleware/ebs_sqs_active_job_middleware'
 
 require_relative 'action_dispatch/session/dynamodb_store'
-require_relative 'active_job/queue_adapters/sqs_adapter'
-require_relative 'active_job/queue_adapters/sqs_adapter/params'
-require_relative 'active_job/queue_adapters/sqs_async_adapter'
 
 require_relative 'generators/aws_record/base'
 

--- a/lib/aws/rails/sqs_active_job.rb
+++ b/lib/aws/rails/sqs_active_job.rb
@@ -14,6 +14,20 @@ module Aws
     # == AWS SQS ActiveJob.
     #
     # SQS-based queuing backend for Active Job.
-    module SqsActiveJob; end
+    module SqsActiveJob
+      # @return [Configuration] the (singleton) Configuration
+      def self.config
+        @config ||= Configuration.new
+      end
+
+      # @yield Configuration
+      def self.configure
+        yield(config)
+      end
+
+      def self.fifo?(queue_url)
+        queue_url.ends_with? '.fifo'
+      end
+    end
   end
 end

--- a/lib/aws/rails/sqs_active_job.rb
+++ b/lib/aws/rails/sqs_active_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative '../../active_job/queue_adapters/sqs_adapter'
+require_relative '../../active_job/queue_adapters/sqs_adapter/params'
+require_relative '../../active_job/queue_adapters/sqs_async_adapter'
+require_relative 'sqs_active_job/configuration'
+require_relative 'sqs_active_job/deduplication'
+require_relative 'sqs_active_job/executor'
+require_relative 'sqs_active_job/job_runner'
+require_relative 'sqs_active_job/lambda_handler'
+
+module Aws
+  module Rails
+    # == AWS SQS ActiveJob.
+    #
+    # SQS-based queuing backend for Active Job.
+    module SqsActiveJob; end
+  end
+end

--- a/lib/aws/rails/sqs_active_job/configuration.rb
+++ b/lib/aws/rails/sqs_active_job/configuration.rb
@@ -4,20 +4,6 @@ module Aws
   module Rails
     # Configuration for AWS SQS ActiveJob.
     module SqsActiveJob
-      # @return [Configuration] the (singleton) Configuration
-      def self.config
-        @config ||= Configuration.new
-      end
-
-      # @yield Configuration
-      def self.configure
-        yield(config)
-      end
-
-      def self.fifo?(queue_url)
-        queue_url.ends_with? '.fifo'
-      end
-
       # Use +Aws::Rails::SqsActiveJob.config+ to access the singleton config instance.
       class Configuration
         # Default configuration options

--- a/spec/aws/rails/sqs_active_job/configuration_spec.rb
+++ b/spec/aws/rails/sqs_active_job/configuration_spec.rb
@@ -49,36 +49,6 @@ module Aws
           expect { Aws::Rails::SqsActiveJob::Configuration.new }.to_not raise_error
         end
 
-        describe '.config' do
-          before { Aws::Rails::SqsActiveJob.instance_variable_set(:@config, nil) }
-
-          it 'creates and returns configuration' do
-            expect(Aws::Rails::SqsActiveJob::Configuration).to receive(:new).and_call_original
-            expect(Aws::Rails::SqsActiveJob.config).to be_a Aws::Rails::SqsActiveJob::Configuration
-          end
-
-          it 'creates config only once' do
-            expect(Aws::Rails::SqsActiveJob::Configuration).to receive(:new).once.and_call_original
-            # call twice
-            Aws::Rails::SqsActiveJob.config
-            Aws::Rails::SqsActiveJob.config
-          end
-        end
-
-        describe '.configure' do
-          it 'allows configuration through a block' do
-            Aws::Rails::SqsActiveJob.configure do |config|
-              config.visibility_timeout = 360
-              config.excluded_deduplication_keys = [:job_class]
-            end
-
-            expect(Aws::Rails::SqsActiveJob.config).to have_attributes(
-              visibility_timeout: 360,
-              excluded_deduplication_keys: contain_exactly('job_class', 'job_id')
-            )
-          end
-        end
-
         describe '#client' do
           it 'does not create client on initialize' do
             expect(Aws::SQS::Client).not_to receive(:new)

--- a/spec/aws/rails/sqs_active_job_spec.rb
+++ b/spec/aws/rails/sqs_active_job_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Aws
+  module Rails
+    describe SqsActiveJob do
+      describe '.config' do
+        before { Aws::Rails::SqsActiveJob.instance_variable_set(:@config, nil) }
+
+        it 'creates and returns configuration' do
+          expect(Aws::Rails::SqsActiveJob::Configuration).to receive(:new).and_call_original
+          expect(Aws::Rails::SqsActiveJob.config).to be_a Aws::Rails::SqsActiveJob::Configuration
+        end
+
+        it 'creates config only once' do
+          expect(Aws::Rails::SqsActiveJob::Configuration).to receive(:new).once.and_call_original
+          # call twice
+          Aws::Rails::SqsActiveJob.config
+          Aws::Rails::SqsActiveJob.config
+        end
+      end
+
+      describe '.configure' do
+        it 'allows configuration through a block' do
+          Aws::Rails::SqsActiveJob.configure do |config|
+            config.visibility_timeout = 360
+            config.excluded_deduplication_keys = [:job_class]
+          end
+
+          expect(Aws::Rails::SqsActiveJob.config).to have_attributes(
+            visibility_timeout: 360,
+            excluded_deduplication_keys: contain_exactly('job_class', 'job_id')
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/aws/rails/sqs_active_job_spec.rb
+++ b/spec/aws/rails/sqs_active_job_spec.rb
@@ -34,6 +34,18 @@ module Aws
           )
         end
       end
+
+      describe '.fifo?' do
+        it 'returns true if queue_url is fifo' do
+          queue_url = 'https://sqs.us-west-2.amazonaws.com/012345678910/queue.fifo'
+          expect(Aws::Rails::SqsActiveJob.fifo?(queue_url)).to be(true)
+        end
+
+        it 'returns false if queue_url is not fifo' do
+          queue_url = 'https://sqs.us-west-2.amazonaws.com/012345678910/queue'
+          expect(Aws::Rails::SqsActiveJob.fifo?(queue_url)).to be(false)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
partially related: #133

We are using the gem just for processing async job on ActiveJob.
Since we don't need any other functionality of the gem, we would like a way to use it easily like the following.

```ruby
gem 'aws-sdk-rails', require: false

require 'aws/rails/sqs_active_job' # load modules just about worker

module MyApplication
  class Application < Rails::Application
    config.active_job.queue_adapter = :sqs
  end
end
```

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
