### PR TITLE
Run CI against rails 7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
           - rails: main
             ruby: 3.0
           # JDBC adapters don't support the latest Rails
+          - rails: 7.2
+            ruby: jruby-9.4
           - rails: main
             ruby: jruby-9.4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,14 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [2.7, '3.0', 3.1, 3.2, 3.3, jruby-9.4]
-        rails: ['7.0', 7.1, main]
+        rails: ['7.0', 7.1, 7.2, main]
 
         exclude:
           # Rails 7.1 dropped support for older rubygems
+          - rails: 7.2
+            ruby: 2.7
+          - rails: 7.2
+            ruby: 3.0
           - rails: main
             ruby: 2.7
           - rails: main

--- a/Gemfile
+++ b/Gemfile
@@ -13,26 +13,8 @@ group :development do
 end
 
 group :test do
-  # JDBC versions track Rails versions
-  if ENV['RAILS_VERSION'] == '7.0'
-    gem 'activerecord-jdbcsqlite3-adapter', '~> 70.0', platform: :jruby
-  elsif ENV['RAILS_VERSION'] == '7.1'
-    gem 'activerecord-jdbc-adapter', '~> 71.0',
-        platform: :jruby,
-        # this is not published for some reason
-        git: 'https://github.com/jruby/activerecord-jdbc-adapter',
-        glob: 'activerecord-jdbc-adapter.gemspec'
-    gem 'activerecord-jdbcsqlite3-adapter', '~> 71.0',
-        platform: :jruby,
-        # this is not published for some reason
-        git: 'https://github.com/jruby/activerecord-jdbc-adapter',
-        glob: 'activerecord-jdbcsqlite3-adapter/activerecord-jdbcsqlite3-adapter.gemspec'
-  end
-
   gem 'bcrypt'
   gem 'rspec-rails'
-  # last supported version of sqlite3 for minimum ruby
-  gem 'sqlite3', '~> 1.6.0', platform: :ruby
   gem 'webmock'
 end
 

--- a/gemfiles/rails-7.0.gemfile
+++ b/gemfiles/rails-7.0.gemfile
@@ -3,3 +3,10 @@
 eval_gemfile '../Gemfile'
 
 gem 'rails', '~> 7.0.0'
+
+group :test do
+  # JDBC versions track Rails versions
+  gem 'activerecord-jdbcsqlite3-adapter', '~> 70.0', platform: :jruby
+  # last supported version of sqlite3 for minimum ruby
+  gem 'sqlite3', '~> 1.6.0', platform: :ruby
+end

--- a/gemfiles/rails-7.1.gemfile
+++ b/gemfiles/rails-7.1.gemfile
@@ -3,3 +3,19 @@
 eval_gemfile '../Gemfile'
 
 gem 'rails', '~> 7.1.0'
+
+group :test do
+  # JDBC versions track Rails versions
+  gem 'activerecord-jdbc-adapter', '~> 71.0',
+      platform: :jruby,
+      # this is not published for some reason
+      git: 'https://github.com/jruby/activerecord-jdbc-adapter',
+      glob: 'activerecord-jdbc-adapter.gemspec'
+  gem 'activerecord-jdbcsqlite3-adapter', '~> 71.0',
+      platform: :jruby,
+      # this is not published for some reason
+      git: 'https://github.com/jruby/activerecord-jdbc-adapter',
+      glob: 'activerecord-jdbcsqlite3-adapter/activerecord-jdbcsqlite3-adapter.gemspec'
+  # last supported version of sqlite3 for minimum ruby
+  gem 'sqlite3', '~> 1.6.0', platform: :ruby
+end

--- a/gemfiles/rails-7.2.gemfile
+++ b/gemfiles/rails-7.2.gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+eval_gemfile '../Gemfile'
+
+gem 'rails', '~> 7.2.0'

--- a/gemfiles/rails-7.2.gemfile
+++ b/gemfiles/rails-7.2.gemfile
@@ -3,3 +3,19 @@
 eval_gemfile '../Gemfile'
 
 gem 'rails', '~> 7.2.0'
+
+group :test do
+  # JDBC versions track Rails versions
+  gem 'activerecord-jdbc-adapter', '~> 71.0',
+      platform: :jruby,
+      # this is not published for some reason
+      git: 'https://github.com/jruby/activerecord-jdbc-adapter',
+      glob: 'activerecord-jdbc-adapter.gemspec'
+  gem 'activerecord-jdbcsqlite3-adapter', '~> 71.0',
+      platform: :jruby,
+      # this is not published for some reason
+      git: 'https://github.com/jruby/activerecord-jdbc-adapter',
+      glob: 'activerecord-jdbcsqlite3-adapter/activerecord-jdbcsqlite3-adapter.gemspec'
+  # last supported version of sqlite3 for minimum ruby
+  gem 'sqlite3', '~> 1.6.0', platform: :ruby
+end

--- a/gemfiles/rails-main.gemfile
+++ b/gemfiles/rails-main.gemfile
@@ -3,3 +3,18 @@
 eval_gemfile '../Gemfile'
 
 gem 'rails', github: 'rails/rails'
+
+group :test do
+  # JDBC versions track Rails versions
+  gem 'activerecord-jdbc-adapter', '~> 71.0',
+      platform: :jruby,
+      # this is not published for some reason
+      git: 'https://github.com/jruby/activerecord-jdbc-adapter',
+      glob: 'activerecord-jdbc-adapter.gemspec'
+  gem 'activerecord-jdbcsqlite3-adapter', '~> 71.0',
+      platform: :jruby,
+      # this is not published for some reason
+      git: 'https://github.com/jruby/activerecord-jdbc-adapter',
+      glob: 'activerecord-jdbcsqlite3-adapter/activerecord-jdbcsqlite3-adapter.gemspec'
+  gem 'sqlite3', '~> 2.0.0', platform: :ruby
+end


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

This pull request adds Rails 7.2 to the test matrix in CI.
Besides, I reorganized `Gemfile` so that each Rails version's Gemfile requires corresponding other gem versions.

Note: I wasn't able to pass tests for `activerecord-jdbc-adapter` since they hasn't published any version that accepts Rails 7.2.0.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
