### PR TITLE
SDK Eager loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Add SDK eager loading to optimize load times.  See: https://github.com/aws/aws-sdk-ruby/pull/3105.
+
 4.0.3 (2024-07-31)
 ------------------
 

--- a/lib/aws/rails/railtie.rb
+++ b/lib/aws/rails/railtie.rb
@@ -18,6 +18,23 @@ module Aws
         Aws::Rails.add_sqsd_middleware(app)
       end
 
+      initializer 'aws-sdk-rails.sdk_eager_load' do
+        config.before_eager_load do
+          config.eager_load_namespaces << Aws
+        end
+
+        Aws.define_singleton_method(:eager_load!) do
+          Aws.constants.each do |c|
+            m = Aws.const_get(c)
+            next unless m.is_a?(Module)
+
+            m.constants.each do |constant|
+              m.const_get(constant)
+            end
+          end
+        end
+      end
+
       rake_tasks do
         load 'tasks/dynamo_db/session_store.rake'
         load 'tasks/aws_record/migrate.rake'
@@ -66,12 +83,18 @@ module Aws
     # name of: put_object.S3.aws
     def self.instrument_sdk_operations
       Aws.constants.each do |c|
+        next if Aws.autoload?(c)
+
         m = Aws.const_get(c)
         if m.is_a?(Module) && m.const_defined?(:Client) &&
            m.const_get(:Client).superclass == Seahorse::Client::Base
           m.const_get(:Client).add_plugin(Aws::Rails::Notifications)
         end
       end
+    end
+
+    def self.setup_sdk_eager_load
+
     end
 
     # Register a middleware that will handle requests from the Elastic Beanstalk worker SQS Daemon.

--- a/lib/aws/rails/railtie.rb
+++ b/lib/aws/rails/railtie.rb
@@ -93,10 +93,6 @@ module Aws
       end
     end
 
-    def self.setup_sdk_eager_load
-
-    end
-
     # Register a middleware that will handle requests from the Elastic Beanstalk worker SQS Daemon.
     # This will only be added in the presence of the AWS_PROCESS_BEANSTALK_WORKER_REQUESTS environment variable.
     # The expectation is this variable should only be set on EB worker environments.

--- a/spec/aws/rails/railtie_spec.rb
+++ b/spec/aws/rails/railtie_spec.rb
@@ -23,6 +23,11 @@ module Aws
         expect(Aws.config[:logger]).to eq ::Rails.logger
       end
 
+      it 'sets up eager loading for sdk services' do
+        expect(Aws.methods).to include(:eager_load!)
+        expect(::Rails.application.config.eager_load_namespaces).to include(Aws)
+      end
+
       describe '.use_rails_encrypted_credentials' do
         let(:rails_creds) { ::Rails.application.credentials.aws }
         it 'sets aws credentials' do

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -3,4 +3,5 @@ Rails.application.configure do
   config.action_mailbox.ingress = :ses
   config.action_mailbox.ses.subscribed_topic = 'arn:aws:sns:eu-west-1:012345678910:example-topic'
   config.action_dispatch.show_exceptions = :none
+  config.eager_load = true
 end


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds in eager loading for the SDK to optimize the start up/require times.  See: https://github.com/aws/aws-sdk-ruby/pull/3105 for more context and in particular see [(revereted) commit](https://github.com/aws/aws-sdk-ruby/pull/3105/commits/44fd76db259a1fcf0360cfbf1380c29f96ec794b#diff-b6240d08ff9163bd4ab7228022ca912b81d68f07d62abed19757f8c2370c34b4) that added railties to each gem with eager_load.


By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
