### PR TITLE
Check existence of dockerenv to verify in docker container, to correct issue in AL2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,19 @@ queues:
   default: 'https://my-queue-url.amazon.aws'
 ```
 
+Or (note the key must be a symbol):
+
+```ruby
+Aws::Rails::SqsActiveJob.configure do |config|
+  config.queues = {
+    :default => 'https://my-queue-url.amazon.aws',
+    ENV.fetch('JOB_QUEUE_NAME').to_sym => 'https://my-other-queue-url.amazon.aws',
+  }
+end
+```
+
 To queue a job, you can just use standard ActiveJob methods:
+
 ```ruby
 # To queue for immediate processing
 YourJob.perform_later(args)
@@ -524,14 +536,14 @@ require_relative 'config/environment' # load rails
 ### Elastic Beanstalk workers: processing activejobs using worker environments
 
 Another option for processing jobs without managing the worker process is hosting the application in a scalable
-[Elastic Beanstalk worker environment](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features-managing-env-tiers.html).  
-[Configure the worker](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features-managing-env-tiers.html#using-features-managing-env-tiers-worker-settings) 
-to read from the correct SQS queue that you want to process jobs from and set the 
+[Elastic Beanstalk worker environment](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features-managing-env-tiers.html).
+[Configure the worker](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features-managing-env-tiers.html#using-features-managing-env-tiers-worker-settings)
+to read from the correct SQS queue that you want to process jobs from and set the
 ```AWS_PROCESS_BEANSTALK_WORKER_REQUESTS``` environment variable to `true` in the worker environment configuration.
 Note that this will NOT start the poller.  Instead the
 [SQS Daemon](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features-managing-env-tiers.html#worker-daemon)
-running on the worker sends messages as a POST request to `http://localhost/`. The middleware will forward each 
-request and parameters to their appropriate jobs. The middleware will only process requests from the SQS daemon 
+running on the worker sends messages as a POST request to `http://localhost/`. The middleware will forward each
+request and parameters to their appropriate jobs. The middleware will only process requests from the SQS daemon
 and will pass on others and so will not interfere with other routes in your application.
 
 To add the middleware on application startup, set the ```AWS_PROCESS_BEANSTALK_WORKER_REQUESTS``` environment variable to true

--- a/lib/aws/rails/middleware/ebs_sqs_active_job_middleware.rb
+++ b/lib/aws/rails/middleware/ebs_sqs_active_job_middleware.rb
@@ -85,7 +85,7 @@ module Aws
       end
 
       def app_runs_in_docker_container?
-        @app_runs_in_docker_container ||= in_docker_container_with_cgroup1? || in_docker_container_with_cgroup2?
+        @app_runs_in_docker_container ||= File.exist?('/.dockerenv') || in_docker_container_with_cgroup1? || in_docker_container_with_cgroup2?
       end
 
       def in_docker_container_with_cgroup1?

--- a/spec/aws/rails/middleware/ebs_sqs_active_job_middleware_spec.rb
+++ b/spec/aws/rails/middleware/ebs_sqs_active_job_middleware_spec.rb
@@ -118,6 +118,20 @@ module Aws
         expect(response[2]).to eq(['Successfully ran job ElasticBeanstalkJob.'])
       end
 
+      it 'successfully invokes job in docker container with dockerenv' do
+        mock_rack_env = create_mock_env('172.17.0.1', 'aws-sqsd/1.1', is_periodic_task: false)
+        test_middleware = EbsSqsActiveJobMiddleware.new(mock_rack_app)
+
+        allow(File).to receive(:exist?).and_call_original
+        expect(File).to receive(:exist?).with('/.dockerenv').and_return(true)
+
+        response = test_middleware.call(mock_rack_env)
+
+        expect(response[0]).to eq(200)
+        expect(response[1]['Content-Type']).to eq('text/plain')
+        expect(response[2]).to eq(['Successfully ran job ElasticBeanstalkJob.'])
+      end
+
       it 'successfully invokes job in docker container with cgroup1' do
         mock_rack_env = create_mock_env('172.17.0.1', 'aws-sqsd/1.1', is_periodic_task: false)
         test_middleware = EbsSqsActiveJobMiddleware.new(mock_rack_app)


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-rails/issues/154

*Description of changes:*

Solution taken from https://github.com/active-elastic-job/active-elastic-job/pull/154 — trying to create a path to deprecate that gem and recommend this gem, and this is an issue that prevents a clear migration 😁 . 

Not sure if we need to ask that PR author for permission, it _was_ merged into an MIT repo. 