### PR TITLE
feat: Restrict which job classes the Elastic Beanstalk SQSD middleware will execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Unreleased Changes
 ------------------
 
+* Issue - Validate that job classes inherit from `ActiveJob::Base` before execution in Elastic Beanstalk SQS middleware.
+* Feature - Add optional `job_class_allowlist` class attribute to `ElasticBeanstalkSQSD` middleware to restrict which job classes can be dispatched.
+
 5.1.0 (2024-12-05)
 ------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 Unreleased Changes
 ------------------
 
-* Issue - Only classes inheriting from `ActiveJob::Base` are executed by the `ElasticBeanstalkSQSD` middleware, preventing arbitrary classes named in an SQS message from being instantiated and run.
-* Feature - Add optional `job_class_allowlist` configuration to `ElasticBeanstalkSQSD` middleware to restrict which job classes can be dispatched.
+* Issue - Only classes inheriting from `ActiveJob::Base` are executed by the `ElasticBeanstalkSQSD` middleware, preventing arbitrary classes named in an SQS message from being instantiated and run. Job class and periodic task names are validated as constant paths and resolved without searching the namespace's ancestors, so a request cannot name a constant outside the intended namespace.
+* Feature - Adds a new configuration object for elastic beanstalk sqsd middleware, with an optional `job_class_allowlist` configuration to `ElasticBeanstalkSQSD` middleware to restrict which job classes can be dispatched. When set, the allowlist is checked before the class name is resolved, so an excluded class is never loaded.
 
 5.1.0 (2024-12-05)
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 Unreleased Changes
 ------------------
 
-* Issue - Validate that job classes inherit from `ActiveJob::Base` before execution in Elastic Beanstalk SQS middleware.
-* Feature - Add optional `job_class_allowlist` class attribute to `ElasticBeanstalkSQSD` middleware to restrict which job classes can be dispatched.
+* Issue - Only classes inheriting from `ActiveJob::Base` are executed by the `ElasticBeanstalkSQSD` middleware, preventing arbitrary classes named in an SQS message from being instantiated and run.
+* Feature - Add optional `job_class_allowlist` configuration to `ElasticBeanstalkSQSD` middleware to restrict which job classes can be dispatched.
 
 5.1.0 (2024-12-05)
 ------------------

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,11 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake', require: false
+if defined?(JRUBY_VERSION)
+  gem 'rdoc', '< 8.0.0'
+else
+  gem 'rdoc'
+end
 
 case ENV.fetch('RAILS_VERSION', nil)
 when '7.1'

--- a/README.md
+++ b/README.md
@@ -131,8 +131,19 @@ appropriate jobs. The middleware will only process requests from the SQS daemon
 and will pass on others and so will not interfere with other routes in your
 application.
 
-To protect against forgeries, daemon requests will only be processed if they
-originate from localhost or the Docker host.
+Only job classes that inherit from `ActiveJob::Base` will be executed. You can
+further restrict which jobs are allowed by configuring an allowlist:
+
+```ruby
+# config/initializers/aws.rb
+Aws::Rails::Middleware::ElasticBeanstalkSQSD.job_class_allowlist = [SomeJob, AnotherJob]
+```
+
+**Important:** Ensure that your worker environment's port 80 is not accessible
+from outside the instance (e.g. via security group rules). The middleware
+performs a local-origin check, but on Docker-based EB platforms all traffic is
+proxied through the Docker bridge and appears as a local request regardless of
+its true origin.
 
 #### Running Jobs Async
 By default the ElasticBeanstalkSQSD middleware will process jobs synchronously

--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ further restrict which jobs are allowed by configuring an allowlist:
 
 ```ruby
 # config/initializers/aws.rb
-Aws::Rails::Middleware::ElasticBeanstalkSQSD.job_class_allowlist = [SomeJob, AnotherJob]
+Aws::Rails::Middleware::ElasticBeanstalkSQSD.configure do |config|
+  config.job_class_allowlist = [SomeJob, AnotherJob]
+end
 ```
 
 **Important:** Ensure that your worker environment's port 80 is not accessible

--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ Aws::Rails::Middleware::ElasticBeanstalkSQSD.configure do |config|
 end
 ```
 
+The allowlist is checked before the class name is resolved, so a request naming
+a class outside the list cannot cause that class to be loaded. It applies to
+periodic task names from `cron.yaml` as well as to job messages.
+
 **Important:** Ensure that your worker environment's port 80 is not accessible
 from outside the instance (e.g. via security group rules). The middleware
 performs a local-origin check, but on Docker-based EB platforms all traffic is

--- a/lib/aws-sdk-rails.rb
+++ b/lib/aws-sdk-rails.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'aws/rails/middleware/elastic_beanstalk_sqsd/configuration'
 require_relative 'aws/rails/middleware/elastic_beanstalk_sqsd'
 require_relative 'aws/rails/railtie'
 require_relative 'aws/rails/notifications'

--- a/lib/aws/rails/middleware/elastic_beanstalk_sqsd.rb
+++ b/lib/aws/rails/middleware/elastic_beanstalk_sqsd.rb
@@ -177,7 +177,7 @@ module Aws
         end
 
         def validate_job_class!(name)
-          klass = name.constantize # lgtm[rb/code-injection]
+          klass = name.constantize # CodeQL [rb/code-injection] Mitigated by ActiveJob::Base ancestry check below
           unless klass.is_a?(Class) && klass < ::ActiveJob::Base
             raise ArgumentError, "#{name} is not a valid job class (must inherit from ActiveJob::Base)"
           end

--- a/lib/aws/rails/middleware/elastic_beanstalk_sqsd.rb
+++ b/lib/aws/rails/middleware/elastic_beanstalk_sqsd.rb
@@ -12,10 +12,12 @@ module Aws
       class ElasticBeanstalkSQSD # rubocop:disable Metrics/ClassLength
         # Configuration for the {ElasticBeanstalkSQSD} middleware.
         class Configuration
-          # @return [Array<Class>, nil] Optional list of job classes permitted
-          #   to be executed. When set, only classes in this list will be
-          #   dispatched. When nil, any class inheriting from ActiveJob::Base
-          #   is allowed.
+          # @return [Array<Class, String>, nil] Optional list of job classes
+          #   permitted to be executed. When set, only classes in this list
+          #   will be dispatched. When nil, any class inheriting from
+          #   ActiveJob::Base is allowed. Entries may be given as Class objects
+          #   or Strings; matching is by class name, so an allowlisted class is
+          #   still recognized after a Zeitwerk reload replaces the class object.
           attr_accessor :job_class_allowlist
         end
 
@@ -120,21 +122,24 @@ module Aws
           # Jobs queued from the SQS adapter contain the JSON message in the request body.
           job = ::ActiveSupport::JSON.decode(request.body.string)
           job_name = job['job_class']
-          validate_job_class!(job_name)
+          # Scope the rescue to resolution only. A NameError raised from inside
+          # the job's own #perform must not be mislabeled as a class-resolution
+          # failure, so ::ActiveJob::Base.execute runs outside the begin/rescue.
+          begin
+            resolve_job_class(job_name)
+          rescue NameError, InvalidJobClassError => e
+            return unresolved_job_class_response(job_name, e)
+          end
           @logger.debug("Executing job: #{job_name}")
           ::ActiveJob::Base.execute(job)
           [200, { 'Content-Type' => 'text/plain' }, ["Successfully ran job #{job_name}."]]
-        rescue NameError, InvalidJobClassError => e
-          @logger.error("Job #{job_name} could not resolve to a class that inherits from Active Job.")
-          @logger.error("Error: #{e}")
-          internal_error_response
         end
 
         # Execute a job using the thread pool executor
-        def _execute_job_background(request) # rubocop:disable Metrics/MethodLength
+        def _execute_job_background(request)
           job_data = ::ActiveSupport::JSON.decode(request.body.string)
           job_name = job_data['job_class']
-          validate_job_class!(job_name)
+          resolve_job_class(job_name)
           @logger.debug("Queuing background job: #{job_name}")
           @executor.post(job_data) do |job|
             ::ActiveJob::Base.execute(job)
@@ -145,26 +150,27 @@ module Aws
           @logger.info(msg)
           [429, { 'Content-Type' => 'text/plain' }, [msg]]
         rescue NameError, InvalidJobClassError => e
-          @logger.error("Job #{job_name} could not resolve to a class that inherits from Active Job.")
-          @logger.error("Error: #{e}")
-          internal_error_response
+          unresolved_job_class_response(job_name, e)
         end
 
         def execute_periodic_task(request)
           # The beanstalk worker SQS Daemon will add the 'X-Aws-Sqsd-Taskname' for periodic tasks set in cron.yaml.
           job_name = request.headers['X-Aws-Sqsd-Taskname']
-          validate_job_class!(job_name)
-          job = job_name.constantize.new
+          # Resolve once and reuse the class, rather than resolving the name a
+          # second time with another constantize (which also left a check-then-
+          # act gap between what was validated and what ran). Scope the rescue
+          # to resolution only, so a NameError from inside the task's own
+          # #perform is not mislabeled as a cron-name resolution failure.
+          begin
+            job = resolve_job_class(job_name).new
+          rescue NameError, InvalidJobClassError => e
+            return unresolved_periodic_task_response(job_name, e)
+          end
           if @executor
             _execute_periodic_task_background(job)
           else
             _execute_periodic_task_now(job)
           end
-        rescue NameError, InvalidJobClassError => e
-          @logger.error("Periodic task #{job_name} could not resolve to an Active Job class " \
-                        '- check the cron name spelling and set the path as / in cron.yaml.')
-          @logger.error("Error: #{e}.")
-          internal_error_response
         end
 
         def _execute_periodic_task_now(job)
@@ -188,6 +194,19 @@ module Aws
           [500, { 'Content-Type' => 'text/plain' }, [message]]
         end
 
+        def unresolved_job_class_response(job_name, error)
+          @logger.error("Job #{job_name} could not resolve to a class that inherits from Active Job.")
+          @logger.error("Error: #{error}")
+          internal_error_response
+        end
+
+        def unresolved_periodic_task_response(job_name, error)
+          @logger.error("Periodic task #{job_name} could not resolve to an Active Job class " \
+                        '- check the cron name spelling and set the path as / in cron.yaml.')
+          @logger.error("Error: #{error}.")
+          internal_error_response
+        end
+
         def forbidden_response
           message = 'Request with aws-sqsd user agent was made from untrusted address.'
           [403, { 'Content-Type' => 'text/plain' }, [message]]
@@ -206,14 +225,21 @@ module Aws
           request.headers['X-Aws-Sqsd-Taskname'].present? && request.fullpath == '/'
         end
 
-        def validate_job_class!(name)
+        # Resolves +name+ to a job class, raising InvalidJobClassError if it
+        # does not name a class inheriting from ActiveJob::Base or is not in the
+        # configured allowlist. Returns the resolved class so callers can reuse
+        # it without resolving the name a second time.
+        def resolve_job_class(name)
           klass = name.constantize # CodeQL [rb/code-injection] Mitigated by ActiveJob::Base ancestry check below
           unless klass.is_a?(Class) && klass < ::ActiveJob::Base
             raise InvalidJobClassError, "#{name} is not a valid job class (must inherit from ActiveJob::Base)"
           end
 
           allowlist = self.class.config.job_class_allowlist
-          return unless allowlist && !allowlist.include?(klass)
+          # Match by class name, not object identity: in development Zeitwerk
+          # reloads produce a new class object with the same name, so an
+          # allowlist of Class objects would reject every job after a reload.
+          return klass if allowlist.nil? || allowlist.map(&:to_s).include?(klass.name)
 
           raise InvalidJobClassError, "#{name} is not in the configured job_class_allowlist"
         end

--- a/lib/aws/rails/middleware/elastic_beanstalk_sqsd.rb
+++ b/lib/aws/rails/middleware/elastic_beanstalk_sqsd.rb
@@ -7,7 +7,7 @@ module Aws
       #
       # @example Restrict job dispatch to specific classes
       #   Aws::Rails::Middleware::ElasticBeanstalkSQSD.job_class_allowlist = [SendReceiptJob, ProcessOrderJob]
-      class ElasticBeanstalkSQSD
+      class ElasticBeanstalkSQSD # rubocop:disable Metrics/ClassLength
         # Optional list of job classes permitted to be executed. When set, only
         # classes in this list will be dispatched. When nil, any class inheriting
         # from ActiveJob::Base is allowed.
@@ -101,7 +101,7 @@ module Aws
         end
 
         # Execute a job using the thread pool executor
-        def _execute_job_background(request)
+        def _execute_job_background(request) # rubocop:disable Metrics/MethodLength
           job_data = ::ActiveSupport::JSON.decode(request.body.string)
           job_name = job_data['job_class']
           validate_job_class!(job_name)
@@ -177,14 +177,15 @@ module Aws
         end
 
         def validate_job_class!(name)
-          klass = name.constantize
+          klass = name.constantize # lgtm[rb/code-injection]
           unless klass.is_a?(Class) && klass < ::ActiveJob::Base
             raise ArgumentError, "#{name} is not a valid job class (must inherit from ActiveJob::Base)"
           end
+
           allowlist = self.class.job_class_allowlist
-          if allowlist && !allowlist.include?(klass)
-            raise ArgumentError, "#{name} is not in the configured job_class_allowlist"
-          end
+          return unless allowlist && !allowlist.include?(klass)
+
+          raise ArgumentError, "#{name} is not in the configured job_class_allowlist"
         end
 
         def sent_from_docker_host?(request)

--- a/lib/aws/rails/middleware/elastic_beanstalk_sqsd.rb
+++ b/lib/aws/rails/middleware/elastic_beanstalk_sqsd.rb
@@ -4,7 +4,17 @@ module Aws
   module Rails
     module Middleware
       # Middleware to handle requests from the SQS Daemon present on Elastic Beanstalk worker environments.
+      #
+      # @example Restrict job dispatch to specific classes
+      #   Aws::Rails::Middleware::ElasticBeanstalkSQSD.job_class_allowlist = [SendReceiptJob, ProcessOrderJob]
       class ElasticBeanstalkSQSD
+        # Optional list of job classes permitted to be executed. When set, only
+        # classes in this list will be dispatched. When nil, any class inheriting
+        # from ActiveJob::Base is allowed.
+        class << self
+          attr_accessor :job_class_allowlist
+        end
+
         def initialize(app)
           @app = app
           @logger = ::Rails.logger
@@ -22,7 +32,9 @@ module Aws
 
           @logger.debug('aws-sdk-rails middleware detected call from Elastic Beanstalk SQS Daemon.')
 
-          # Only accept requests from this user agent if it is from localhost or a docker host in case of forgery.
+          # Best-effort source check. On Docker-based EB platforms this is unreliable
+          # because all traffic arrives via the docker bridge. Use job_class_allowlist
+          # and network-level controls (security groups) as the primary safeguards.
           unless request.local? || sent_from_docker_host?(request)
             @logger.warn('SQSD request detected from untrusted address; returning 403 forbidden.')
             return forbidden_response
@@ -78,10 +90,11 @@ module Aws
           # Jobs queued from the SQS adapter contain the JSON message in the request body.
           job = ::ActiveSupport::JSON.decode(request.body.string)
           job_name = job['job_class']
+          validate_job_class!(job_name)
           @logger.debug("Executing job: #{job_name}")
           ::ActiveJob::Base.execute(job)
           [200, { 'Content-Type' => 'text/plain' }, ["Successfully ran job #{job_name}."]]
-        rescue NameError => e
+        rescue NameError, ArgumentError => e
           @logger.error("Job #{job_name} could not resolve to a class that inherits from Active Job.")
           @logger.error("Error: #{e}")
           internal_error_response
@@ -90,27 +103,34 @@ module Aws
         # Execute a job using the thread pool executor
         def _execute_job_background(request)
           job_data = ::ActiveSupport::JSON.decode(request.body.string)
-          @logger.debug("Queuing background job: #{job_data['job_class']}")
+          job_name = job_data['job_class']
+          validate_job_class!(job_name)
+          @logger.debug("Queuing background job: #{job_name}")
           @executor.post(job_data) do |job|
             ::ActiveJob::Base.execute(job)
           end
-          [200, { 'Content-Type' => 'text/plain' }, ["Successfully queued job #{job_data['job_class']}"]]
+          [200, { 'Content-Type' => 'text/plain' }, ["Successfully queued job #{job_name}"]]
         rescue Concurrent::RejectedExecutionError
           msg = 'No capacity to execute job.'
           @logger.info(msg)
           [429, { 'Content-Type' => 'text/plain' }, [msg]]
+        rescue NameError, ArgumentError => e
+          @logger.error("Job #{job_name} could not resolve to a class that inherits from Active Job.")
+          @logger.error("Error: #{e}")
+          internal_error_response
         end
 
         def execute_periodic_task(request)
           # The beanstalk worker SQS Daemon will add the 'X-Aws-Sqsd-Taskname' for periodic tasks set in cron.yaml.
           job_name = request.headers['X-Aws-Sqsd-Taskname']
+          validate_job_class!(job_name)
           job = job_name.constantize.new
           if @executor
             _execute_periodic_task_background(job)
           else
             _execute_periodic_task_now(job)
           end
-        rescue NameError => e
+        rescue NameError, ArgumentError => e
           @logger.error("Periodic task #{job_name} could not resolve to an Active Job class " \
                         '- check the cron name spelling and set the path as / in cron.yaml.')
           @logger.error("Error: #{e}.")
@@ -154,6 +174,17 @@ module Aws
         # for periodic tasks set in cron.yaml.
         def periodic_task?(request)
           request.headers['X-Aws-Sqsd-Taskname'].present? && request.fullpath == '/'
+        end
+
+        def validate_job_class!(name)
+          klass = name.constantize
+          unless klass.is_a?(Class) && klass < ::ActiveJob::Base
+            raise ArgumentError, "#{name} is not a valid job class (must inherit from ActiveJob::Base)"
+          end
+          allowlist = self.class.job_class_allowlist
+          if allowlist && !allowlist.include?(klass)
+            raise ArgumentError, "#{name} is not in the configured job_class_allowlist"
+          end
         end
 
         def sent_from_docker_host?(request)

--- a/lib/aws/rails/middleware/elastic_beanstalk_sqsd.rb
+++ b/lib/aws/rails/middleware/elastic_beanstalk_sqsd.rb
@@ -5,26 +5,19 @@ module Aws
     module Middleware
       # Middleware to handle requests from the SQS Daemon present on Elastic Beanstalk worker environments.
       #
-      # @example Restrict job dispatch to specific classes
-      #   Aws::Rails::Middleware::ElasticBeanstalkSQSD.configure do |config|
-      #     config.job_class_allowlist = [SendReceiptJob, ProcessOrderJob]
-      #   end
+      # See {Configuration} for the available options and {configure} for
+      # setting them in code.
       class ElasticBeanstalkSQSD # rubocop:disable Metrics/ClassLength
-        # Configuration for the {ElasticBeanstalkSQSD} middleware.
-        class Configuration
-          # @return [Array<Class, String>, nil] Optional list of job classes
-          #   permitted to be executed. When set, only classes in this list
-          #   will be dispatched. When nil, any class inheriting from
-          #   ActiveJob::Base is allowed. Entries may be given as Class objects
-          #   or Strings; matching is by class name, so an allowlisted class is
-          #   still recognized after a Zeitwerk reload replaces the class object.
-          attr_accessor :job_class_allowlist
-        end
-
         # Raised when a job message names a class that cannot be executed -
-        # either it does not inherit from ActiveJob::Base or it is not in the
-        # configured job_class_allowlist.
+        # the name is not a well-formed constant path, it is not in the
+        # configured job_class_allowlist, or it does not inherit from
+        # ActiveJob::Base.
         class InvalidJobClassError < StandardError; end
+
+        # A job class name is an (optionally namespaced) constant path and
+        # nothing else. Names that cannot match this can never name a job
+        # class, so rejecting them keeps them out of the constant lookup.
+        JOB_CLASS_NAME_PATTERN = /\A[A-Z]\w*(::[A-Z]\w*)*\z/.freeze
 
         class << self
           # Yields the middleware configuration for customization.
@@ -225,23 +218,46 @@ module Aws
           request.headers['X-Aws-Sqsd-Taskname'].present? && request.fullpath == '/'
         end
 
-        # Resolves +name+ to a job class, raising InvalidJobClassError if it
-        # does not name a class inheriting from ActiveJob::Base or is not in the
-        # configured allowlist. Returns the resolved class so callers can reuse
-        # it without resolving the name a second time.
+        # Resolves +name+ to a job class, raising InvalidJobClassError if it is
+        # not a well-formed constant path, is not in the configured allowlist,
+        # or does not name a class inheriting from ActiveJob::Base. Returns the
+        # resolved class so callers can reuse it without resolving the name a
+        # second time.
+        #
+        # Checks are ordered so that the least trusting one runs first. Merely
+        # resolving a constant is not inert: under Zeitwerk it triggers
+        # autoloading, which runs the body of whichever file defines it. So the
+        # name is matched against the allowlist as a String, before any lookup,
+        # and an excluded name never reaches the constant resolver at all.
         def resolve_job_class(name)
-          klass = name.constantize # CodeQL [rb/code-injection] Mitigated by ActiveJob::Base ancestry check below
-          unless klass.is_a?(Class) && klass < ::ActiveJob::Base
-            raise InvalidJobClassError, "#{name} is not a valid job class (must inherit from ActiveJob::Base)"
-          end
+          name = name.to_s
+          raise InvalidJobClassError, "#{name.inspect} is not a valid job class name" unless
+            JOB_CLASS_NAME_PATTERN.match?(name)
 
           allowlist = self.class.config.job_class_allowlist
           # Match by class name, not object identity: in development Zeitwerk
           # reloads produce a new class object with the same name, so an
           # allowlist of Class objects would reject every job after a reload.
-          return klass if allowlist.nil? || allowlist.map(&:to_s).include?(klass.name)
+          if allowlist && !allowlist.map(&:to_s).include?(name)
+            raise InvalidJobClassError, "#{name} is not in the configured job_class_allowlist"
+          end
 
-          raise InvalidJobClassError, "#{name} is not in the configured job_class_allowlist"
+          klass = constantize_job_class(name)
+          unless klass.is_a?(Class) && klass < ::ActiveJob::Base
+            raise InvalidJobClassError, "#{name} is not a valid job class (must inherit from ActiveJob::Base)"
+          end
+
+          klass
+        end
+
+        # Resolves an already-validated name. +inherit+ is false so that each
+        # segment must be defined directly on the preceding one: a name such as
+        # 'SomeJob::Foo' cannot resolve Foo from SomeJob's ancestors when
+        # SomeJob itself does not define it.
+        def constantize_job_class(name)
+          # CodeQL [rb/code-injection] Name is validated against JOB_CLASS_NAME_PATTERN
+          # and the allowlist above, and the result is checked for ActiveJob::Base ancestry below.
+          Object.const_get(name, false)
         end
 
         def sent_from_docker_host?(request)

--- a/lib/aws/rails/middleware/elastic_beanstalk_sqsd.rb
+++ b/lib/aws/rails/middleware/elastic_beanstalk_sqsd.rb
@@ -6,13 +6,43 @@ module Aws
       # Middleware to handle requests from the SQS Daemon present on Elastic Beanstalk worker environments.
       #
       # @example Restrict job dispatch to specific classes
-      #   Aws::Rails::Middleware::ElasticBeanstalkSQSD.job_class_allowlist = [SendReceiptJob, ProcessOrderJob]
+      #   Aws::Rails::Middleware::ElasticBeanstalkSQSD.configure do |config|
+      #     config.job_class_allowlist = [SendReceiptJob, ProcessOrderJob]
+      #   end
       class ElasticBeanstalkSQSD # rubocop:disable Metrics/ClassLength
-        # Optional list of job classes permitted to be executed. When set, only
-        # classes in this list will be dispatched. When nil, any class inheriting
-        # from ActiveJob::Base is allowed.
-        class << self
+        # Configuration for the {ElasticBeanstalkSQSD} middleware.
+        class Configuration
+          # @return [Array<Class>, nil] Optional list of job classes permitted
+          #   to be executed. When set, only classes in this list will be
+          #   dispatched. When nil, any class inheriting from ActiveJob::Base
+          #   is allowed.
           attr_accessor :job_class_allowlist
+        end
+
+        # Raised when a job message names a class that cannot be executed -
+        # either it does not inherit from ActiveJob::Base or it is not in the
+        # configured job_class_allowlist.
+        class InvalidJobClassError < StandardError; end
+
+        class << self
+          # Yields the middleware configuration for customization.
+          #
+          # @example Restrict job dispatch to specific classes
+          #   Aws::Rails::Middleware::ElasticBeanstalkSQSD.configure do |config|
+          #     config.job_class_allowlist = [SendReceiptJob, ProcessOrderJob]
+          #   end
+          #
+          # @yieldparam [Configuration] config
+          # @return [Configuration]
+          def configure
+            yield(config) if block_given?
+            config
+          end
+
+          # @return [Configuration] the current middleware configuration.
+          def config
+            @config ||= Configuration.new
+          end
         end
 
         def initialize(app)
@@ -94,7 +124,7 @@ module Aws
           @logger.debug("Executing job: #{job_name}")
           ::ActiveJob::Base.execute(job)
           [200, { 'Content-Type' => 'text/plain' }, ["Successfully ran job #{job_name}."]]
-        rescue NameError, ArgumentError => e
+        rescue NameError, InvalidJobClassError => e
           @logger.error("Job #{job_name} could not resolve to a class that inherits from Active Job.")
           @logger.error("Error: #{e}")
           internal_error_response
@@ -114,7 +144,7 @@ module Aws
           msg = 'No capacity to execute job.'
           @logger.info(msg)
           [429, { 'Content-Type' => 'text/plain' }, [msg]]
-        rescue NameError, ArgumentError => e
+        rescue NameError, InvalidJobClassError => e
           @logger.error("Job #{job_name} could not resolve to a class that inherits from Active Job.")
           @logger.error("Error: #{e}")
           internal_error_response
@@ -130,7 +160,7 @@ module Aws
           else
             _execute_periodic_task_now(job)
           end
-        rescue NameError, ArgumentError => e
+        rescue NameError, InvalidJobClassError => e
           @logger.error("Periodic task #{job_name} could not resolve to an Active Job class " \
                         '- check the cron name spelling and set the path as / in cron.yaml.')
           @logger.error("Error: #{e}.")
@@ -179,13 +209,13 @@ module Aws
         def validate_job_class!(name)
           klass = name.constantize # CodeQL [rb/code-injection] Mitigated by ActiveJob::Base ancestry check below
           unless klass.is_a?(Class) && klass < ::ActiveJob::Base
-            raise ArgumentError, "#{name} is not a valid job class (must inherit from ActiveJob::Base)"
+            raise InvalidJobClassError, "#{name} is not a valid job class (must inherit from ActiveJob::Base)"
           end
 
-          allowlist = self.class.job_class_allowlist
+          allowlist = self.class.config.job_class_allowlist
           return unless allowlist && !allowlist.include?(klass)
 
-          raise ArgumentError, "#{name} is not in the configured job_class_allowlist"
+          raise InvalidJobClassError, "#{name} is not in the configured job_class_allowlist"
         end
 
         def sent_from_docker_host?(request)

--- a/lib/aws/rails/middleware/elastic_beanstalk_sqsd/configuration.rb
+++ b/lib/aws/rails/middleware/elastic_beanstalk_sqsd/configuration.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Aws
+  module Rails
+    module Middleware
+      class ElasticBeanstalkSQSD
+        # Configuration for the {ElasticBeanstalkSQSD} middleware.
+        #
+        # Use {ElasticBeanstalkSQSD.config} to access the singleton config
+        # instance and {ElasticBeanstalkSQSD.configure} to configure in code:
+        #
+        #     Aws::Rails::Middleware::ElasticBeanstalkSQSD.configure do |config|
+        #       config.job_class_allowlist = [SendReceiptJob, ProcessOrderJob]
+        #     end
+        #
+        class Configuration
+          # @return [Array<Class, String>, nil] Optional list of job classes
+          #   permitted to be executed. When set, only classes in this list
+          #   will be dispatched. When nil, any class inheriting from
+          #   ActiveJob::Base is allowed. Entries may be given as Class objects
+          #   or Strings; matching is by class name, so an allowlisted class is
+          #   still recognized after a Zeitwerk reload replaces the class object.
+          attr_accessor :job_class_allowlist
+        end
+      end
+    end
+  end
+end

--- a/spec/aws/rails/middleware/elastic_beanstalk_sqsd_spec.rb
+++ b/spec/aws/rails/middleware/elastic_beanstalk_sqsd_spec.rb
@@ -39,11 +39,10 @@ module Aws
           end
 
           it 'returns internal server error if job name cannot be resolved' do
-            # Stub execute call to avoid invoking Active Job callbacks
-            # Local testing indicates this failure results in a NameError
-            allow(::ActiveJob::Base).to receive(:execute).and_raise(NameError)
-
-            expect(response[0]).to eq(500)
+            mock_env = create_mock_env
+            mock_env['rack.input'] = StringIO.new('{"job_class": "NoSuchJobClass"}')
+            test_middleware = described_class.new(mock_rack_app)
+            expect(test_middleware.call(mock_env)[0]).to eq(500)
           end
 
           context 'when user-agent is not sqs daemon' do
@@ -245,6 +244,36 @@ module Aws
               response = test_middleware.call(mock_env)
               expect(response[0]).to eq(500)
             end
+
+            context 'when the allowlist holds a stale class object (Zeitwerk reload)' do
+              # Simulate a Zeitwerk reload: the allowlist was populated at boot
+              # with one class object, but the message now resolves to a brand-
+              # new object with the same name. Matching by object identity would
+              # reject it; matching by name must still accept it.
+              let(:stale_class) do
+                Class.new(ElasticBeanstalkJob.superclass).tap do |klass|
+                  allow(klass).to receive(:name).and_return('ElasticBeanstalkJob')
+                  allow(klass).to receive(:to_s).and_return('ElasticBeanstalkJob')
+                end
+              end
+
+              before { described_class.config.job_class_allowlist = [stale_class] }
+
+              it 'still accepts the reloaded, identically-named class' do
+                expect(stale_class).not_to equal(ElasticBeanstalkJob)
+                expect(response[0]).to eq(200)
+              end
+            end
+          end
+
+          it 'does not mislabel a NameError raised from within a valid job' do
+            # A resolvable job whose execution raises NameError (e.g. a typo'd
+            # constant in #perform) must not be treated as a class-resolution
+            # failure. It should propagate rather than becoming a 500 logged as
+            # "could not resolve to a class".
+            allow(::ActiveJob::Base).to receive(:execute)
+              .and_raise(NameError, 'uninitialized constant TypoedConstant')
+            expect { response }.to raise_error(NameError, /TypoedConstant/)
           end
         end
 

--- a/spec/aws/rails/middleware/elastic_beanstalk_sqsd_spec.rb
+++ b/spec/aws/rails/middleware/elastic_beanstalk_sqsd_spec.rb
@@ -221,12 +221,37 @@ module Aws
         context 'job class validation' do
           let(:remote_ip) { '127.0.0.1' }
 
-          it 'rejects classes that do not inherit from ActiveJob::Base' do
+          def response_for(class_name)
             mock_env = create_mock_env
-            mock_env['rack.input'] = StringIO.new('{"job_class": "String"}')
-            test_middleware = described_class.new(mock_rack_app)
-            response = test_middleware.call(mock_env)
-            expect(response[0]).to eq(500)
+            mock_env['rack.input'] = StringIO.new(ActiveSupport::JSON.dump('job_class' => class_name))
+            described_class.new(mock_rack_app).call(mock_env)
+          end
+
+          it 'rejects classes that do not inherit from ActiveJob::Base' do
+            expect(response_for('String')[0]).to eq(500)
+          end
+
+          it 'rejects names that are not well-formed constant paths' do
+            ['', 'elastic_beanstalk_job', 'ElasticBeanstalkJob; puts 1', 'Elastic Beanstalk', '@job'].each do |name|
+              expect(response_for(name)[0]).to eq(500)
+            end
+          end
+
+          it 'does not resolve a name through an ancestor of the namespace' do
+            # ElasticBeanstalkJob does not define CallbackChain, but its
+            # ancestors do, so an inheriting lookup would resolve this to
+            # ActiveSupport::Callbacks::CallbackChain. Such a constant fails
+            # the ActiveJob::Base check regardless, so this asserts on the
+            # resolution itself: names must not reach outside the namespace
+            # they appear to address.
+            middleware = described_class.new(mock_rack_app)
+            expect { middleware.send(:resolve_job_class, 'ElasticBeanstalkJob::CallbackChain') }
+              .to raise_error(NameError)
+          end
+
+          it 'does not resolve the constant when the name is malformed' do
+            expect_any_instance_of(described_class).not_to receive(:constantize_job_class)
+            expect(response_for('not_a_class_name')[0]).to eq(500)
           end
 
           context 'with job_class_allowlist configured' do
@@ -238,11 +263,30 @@ module Aws
             end
 
             it 'rejects classes not in the allowlist' do
-              mock_env = create_mock_env
-              mock_env['rack.input'] = StringIO.new('{"job_class": "ElasticBeanstalkPeriodicTask"}')
-              test_middleware = described_class.new(mock_rack_app)
-              response = test_middleware.call(mock_env)
-              expect(response[0]).to eq(500)
+              expect(response_for('ElasticBeanstalkPeriodicTask')[0]).to eq(500)
+            end
+
+            it 'rejects a disallowed name without resolving its constant' do
+              # Resolving is what triggers autoloading, so a name the allowlist
+              # excludes must be rejected before the lookup happens.
+              expect_any_instance_of(described_class).not_to receive(:constantize_job_class)
+              expect(response_for('ElasticBeanstalkPeriodicTask')[0]).to eq(500)
+            end
+
+            it 'rejects a disallowed name even when it is undefined' do
+              expect(response_for('NoSuchJobClass')[0]).to eq(500)
+            end
+
+            context 'when the request is a periodic task' do
+              let(:is_periodic_task) { true }
+              let(:period_task_name) { 'ElasticBeanstalkPeriodicTask' }
+
+              it 'rejects a disallowed task without resolving its constant' do
+                # The task name comes from a request header, so the periodic
+                # path must gate on the allowlist before resolving too.
+                expect_any_instance_of(described_class).not_to receive(:constantize_job_class)
+                expect(response[0]).to eq(500)
+              end
             end
 
             context 'when the allowlist holds a stale class object (Zeitwerk reload)' do

--- a/spec/aws/rails/middleware/elastic_beanstalk_sqsd_spec.rb
+++ b/spec/aws/rails/middleware/elastic_beanstalk_sqsd_spec.rb
@@ -231,8 +231,8 @@ module Aws
           end
 
           context 'with job_class_allowlist configured' do
-            before { described_class.job_class_allowlist = [ElasticBeanstalkJob] }
-            after { described_class.job_class_allowlist = nil }
+            before { described_class.config.job_class_allowlist = [ElasticBeanstalkJob] }
+            after { described_class.config.job_class_allowlist = nil }
 
             it 'allows classes in the allowlist' do
               expect(response[0]).to eq(200)

--- a/spec/aws/rails/middleware/elastic_beanstalk_sqsd_spec.rb
+++ b/spec/aws/rails/middleware/elastic_beanstalk_sqsd_spec.rb
@@ -219,6 +219,35 @@ module Aws
           include_examples 'is valid in either cgroup1 or cgroup2'
         end
 
+        context 'job class validation' do
+          let(:remote_ip) { '127.0.0.1' }
+
+          it 'rejects classes that do not inherit from ActiveJob::Base' do
+            mock_env = create_mock_env
+            mock_env['rack.input'] = StringIO.new('{"job_class": "String"}')
+            test_middleware = described_class.new(mock_rack_app)
+            response = test_middleware.call(mock_env)
+            expect(response[0]).to eq(500)
+          end
+
+          context 'with job_class_allowlist configured' do
+            before { described_class.job_class_allowlist = [ElasticBeanstalkJob] }
+            after { described_class.job_class_allowlist = nil }
+
+            it 'allows classes in the allowlist' do
+              expect(response[0]).to eq(200)
+            end
+
+            it 'rejects classes not in the allowlist' do
+              mock_env = create_mock_env
+              mock_env['rack.input'] = StringIO.new('{"job_class": "ElasticBeanstalkPeriodicTask"}')
+              test_middleware = described_class.new(mock_rack_app)
+              response = test_middleware.call(mock_env)
+              expect(response[0]).to eq(500)
+            end
+          end
+        end
+
         context 'when AWS_PROCESS_BEANSTALK_WORKER_JOBS_ASYNC' do
           before(:each) do
             ENV['AWS_PROCESS_BEANSTALK_WORKER_JOBS_ASYNC'] = 'true'

--- a/spec/dummy/app/jobs/elastic_beanstalk_job.rb
+++ b/spec/dummy/app/jobs/elastic_beanstalk_job.rb
@@ -3,5 +3,5 @@
 class ElasticBeanstalkJob < ApplicationJob
   queue_as :default
 
-  def perform(); end
+  def perform; end
 end

--- a/spec/dummy/app/jobs/elastic_beanstalk_periodic_task.rb
+++ b/spec/dummy/app/jobs/elastic_beanstalk_periodic_task.rb
@@ -3,5 +3,5 @@
 class ElasticBeanstalkPeriodicTask < ApplicationJob
   queue_as :default
 
-  def perform(); end
+  def perform; end
 end


### PR DESCRIPTION
_This PR summary / description was written with help of AI._

## Summary

The `ElasticBeanstalkSQSD` middleware deserializes the SQS Daemon's request body
and executes the class named in its `job_class` field, or the
`X-Aws-Sqsd-Taskname` header for periodic tasks. Previously any resolvable
constant would be resolved and run, so a request naming an arbitrary class could
cause that class to be executed. This change constrains what the middleware will
run.

## What this changes

`resolve_job_class` now applies three checks, ordered so the least trusting one
runs first:

1. **Name shape** - the name must match `JOB_CLASS_NAME_PATTERN`
   (`/\A[A-Z]\w*(::[A-Z]\w*)*\z/`), an optionally namespaced constant path and
   nothing else. Anything that cannot name a class is rejected before any lookup.
2. **Allowlist, compared as a String** - when `job_class_allowlist` is set, the
   raw name is matched against it *before* the constant is resolved.
3. **Resolve, then verify** - `Object.const_get(name, false)`, then a check that
   the result is a `Class` inheriting from `ActiveJob::Base`.

Both entry points share this method, so the periodic-task path is covered too.
That path is the more exposed of the two, since the name arrives in a request
header rather than a queue message.

Two details worth calling out for review:

- **Ordering.** Resolving a constant is not inert: under Zeitwerk it triggers
  autoloading, which runs the body of whichever file defines it. Checking the
  allowlist first means a disallowed name never reaches the resolver. To be
  precise about severity: this is defense-in-depth, not a code-execution fix.
  `const_get` does not evaluate arbitrary Ruby, and the previous code called only
  `is_a?`, `<`, and `.name` on the resolved class before raising. Checking a
  string against a list is simply cheaper than resolving a constant, and doing
  the cheap check first is the right order regardless.
- **`inherit: false`.** Each segment must be defined directly on the preceding
  one, so a name like `SomeJob::Foo` cannot resolve `Foo` from `SomeJob`'s
  ancestors. Without this, `ElasticBeanstalkJob::CallbackChain` resolves to
  `ActiveSupport::Callbacks::CallbackChain`.

The CodeQL suppression comment moved with the lookup into
`constantize_job_class` and now cites the pattern and allowlist that run before
it, in addition to the ancestry check after.

## Configuring the middleware

Configuration goes through a `.configure` block backed by a `Configuration`
class, which now lives in its own file at
`lib/aws/rails/middleware/elastic_beanstalk_sqsd/configuration.rb` (per review
feedback), mirroring the layout of the sibling `aws-activejob-sqs-ruby` change:

```ruby
# config/initializers/aws.rb
Aws::Rails::Middleware::ElasticBeanstalkSQSD.configure do |config|
  config.job_class_allowlist = [SomeJob, AnotherJob]
end
```

The class is reopened in the new file, so the constant remains
`ElasticBeanstalkSQSD::Configuration` and `.config` / `.configure` are unchanged.
The `require` sits in the `lib/aws-sdk-rails.rb` entry point alongside the
existing flat `require_relative` list, ahead of the middleware.

On keeping `Configuration` nested under the middleware rather than at the gem
module level: both patterns exist in the wild. `Rack::Attack::Configuration` is
nested under the middleware in its own file, which is what this does;
`SecureHeaders::Configuration` sits at the module level, but there the config is
the gem's entire surface and the middleware is an incidental delivery mechanism.
This gem has several unrelated features (logger wiring, encrypted credentials,
SDK instrumentation, notifications) to which `job_class_allowlist` is
meaningless, so scoping it to the middleware that owns it seemed right. Happy to
move it if you'd prefer the module-level shape.

Matching is by class name rather than object identity, so an allowlisted class is
still recognized after a Zeitwerk reload replaces the class object. The allowlist
is configured in code only, taking an array of `Class` objects or name `String`s.
This matches the existing convention in this gem, where behavioral settings are
set in an initializer and ENV vars are reserved for deployment toggles
(`AWS_PROCESS_BEANSTALK_WORKER_*`). The gem has no YAML config-file machinery, so
no file channel is added.

Default remains `nil`, allowing any `ActiveJob::Base` subclass, so existing
behavior is preserved.

## Errors

Invalid or disallowed job classes raise
`ElasticBeanstalkSQSD::InvalidJobClassError` instead of a broad `ArgumentError`,
so unrelated `ArgumentError`s are no longer swallowed by the middleware's rescue
clauses. Failures are logged and return a 500 response, as before.

`NameError` from an unknown constant is left to propagate to the existing
`rescue NameError, InvalidJobClassError` in the callers, preserving the current
500 behavior. Those rescues are scoped to resolution only, so a `NameError`
raised from inside a job's own `#perform` is not mislabeled as a
class-resolution failure.

## Tests

- Rejects classes that do not inherit from `ActiveJob::Base`.
- Rejects names that are not well-formed constant paths.
- Does not resolve the constant when the name is malformed, or when the
  allowlist excludes it (these pin the ordering).
- Does not resolve a disallowed periodic task name from the request header.
- Does not resolve a name through an ancestor of the namespace.
- Allows / rejects classes against a configured `job_class_allowlist`.
- Still accepts an allowlisted class after a simulated Zeitwerk reload replaces
  the class object.
- Does not mislabel a `NameError` raised from within a valid job.

Full suite: 102 examples, 0 failures. Rubocop clean.

The new ordering and `inherit: false` tests were checked against the previous
implementation and fail there, so they pin real behavior rather than passing
incidentally.

## Docs

- README: documents the `.configure` block, notes that the allowlist is checked
  before resolution and applies to periodic task names, and keeps the security
  note about restricting worker port 80 access on Docker-based EB platforms.
- CHANGELOG: entries lead with customer impact.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
