### PR TITLE
fix: Address docker origin check vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased Changes
 ------------------
 
+* Issue - The `ElasticBeanstalkSQSD` middleware's Docker host check now only consults `remote_addr`, the raw TCP peer address, instead of also accepting `remote_ip`. `remote_ip` is derived from the client-supplied `X-Forwarded-For` header whenever the peer address is itself private, so a request from any private address could name the Docker gateway and be treated as local. Loopback peer addresses are accepted by the check, so requests proxied over loopback are unaffected.
 * Issue - Only classes inheriting from `ActiveJob::Base` are executed by the `ElasticBeanstalkSQSD` middleware, preventing arbitrary classes named in an SQS message from being instantiated and run. Job class and periodic task names are validated as constant paths and resolved without searching the namespace's ancestors, so a request cannot name a constant outside the intended namespace.
 * Feature - Adds a new configuration object for elastic beanstalk sqsd middleware, with an optional `job_class_allowlist` configuration to `ElasticBeanstalkSQSD` middleware to restrict which job classes can be dispatched. When set, the allowlist is checked before the class name is resolved, so an excluded class is never loaded.
 

--- a/README.md
+++ b/README.md
@@ -146,10 +146,14 @@ a class outside the list cannot cause that class to be loaded. It applies to
 periodic task names from `cron.yaml` as well as to job messages.
 
 **Important:** Ensure that your worker environment's port 80 is not accessible
-from outside the instance (e.g. via security group rules). The middleware
-performs a local-origin check, but on Docker-based EB platforms all traffic is
-proxied through the Docker bridge and appears as a local request regardless of
-its true origin.
+from outside the instance (e.g. via security group rules). The middleware only
+accepts daemon requests whose TCP peer address is loopback or the Docker
+gateway, which cannot be forged with a request header. On Docker-based EB
+platforms, however, inbound traffic is proxied into the container by the host,
+so its peer address is genuinely the Docker gateway regardless of where the
+request originated. Network-level controls are therefore the primary safeguard,
+with `job_class_allowlist` limiting what a request that does get through can
+reach.
 
 #### Running Jobs Async
 By default the ElasticBeanstalkSQSD middleware will process jobs synchronously

--- a/lib/aws/rails/middleware/elastic_beanstalk_sqsd.rb
+++ b/lib/aws/rails/middleware/elastic_beanstalk_sqsd.rb
@@ -276,9 +276,17 @@ module Aws
           File.exist?('/proc/self/mountinfo') && File.read('/proc/self/mountinfo') =~ %r{/docker/containers/}
         end
 
+        # Only consults remote_addr, the raw TCP peer address. remote_ip is
+        # derived from X-Forwarded-For whenever the peer is itself private, and
+        # the docker gateway range (172.16.0.0/12) is one Rack treats as a
+        # trusted proxy to see through - so a request from any private peer can
+        # set remote_ip to the gateway with a header alone. Loopback is accepted
+        # here because such a request is genuinely local; request.local? rejects
+        # it only on the forgeable half of its check.
         def ip_originates_from_docker_host?(request)
-          default_docker_ips.include?(request.remote_ip) ||
-            default_docker_ips.include?(request.remote_addr)
+          remote_addr = request.remote_addr
+          default_docker_ips.include?(remote_addr) ||
+            ::ActionDispatch::Request::LOCALHOST.match?(remote_addr)
         end
 
         def default_docker_ips

--- a/spec/aws/rails/middleware/elastic_beanstalk_sqsd_spec.rb
+++ b/spec/aws/rails/middleware/elastic_beanstalk_sqsd_spec.rb
@@ -17,6 +17,7 @@ module Aws
         let(:user_agent) { 'aws-sqsd/1.1' }
         let(:remote_ip) { '127.0.0.1' }
         let(:remote_addr) { nil }
+        let(:forwarded_for) { nil }
         let(:is_periodic_task) { nil }
         let(:period_task_name) { 'ElasticBeanstalkPeriodicTask' }
 
@@ -206,14 +207,31 @@ module Aws
           include_examples 'is invalid in either cgroup1 or cgroup2'
         end
 
-        context 'when remote ip is default docker gw' do
-          let(:remote_ip) { '172.17.0.1' }
+        context 'when remote addr is default docker gw' do
+          let(:remote_addr) { '172.17.0.1' }
 
           include_examples 'is valid in either cgroup1 or cgroup2'
         end
 
-        context 'when remote addr is default docker gw' do
-          let(:remote_addr) { '172.17.0.1' }
+        context 'when remote addr is untrusted but X-Forwarded-For claims the docker gw' do
+          # remote_addr is the raw TCP peer and cannot be forged over HTTP, but
+          # remote_ip is derived from X-Forwarded-For once the peer is private.
+          # A private peer must not become trusted by naming the gateway itself.
+          let(:remote_addr) { '172.31.5.20' }
+          let(:forwarded_for) { '172.17.0.1' }
+
+          it 'resolves remote_ip to the forged value' do
+            expect(::ActionDispatch::Request.new(create_mock_env).remote_ip).to eq('172.17.0.1')
+          end
+
+          include_examples 'is invalid in either cgroup1 or cgroup2'
+        end
+
+        context 'when remote addr is loopback but X-Forwarded-For claims the docker gw' do
+          # Genuinely local: request.local? rejects this only because remote_ip
+          # is not loopback, so the docker check has to accept it on remote_addr.
+          let(:remote_addr) { '127.0.0.1' }
+          let(:forwarded_for) { '172.17.0.1' }
 
           include_examples 'is valid in either cgroup1 or cgroup2'
         end
@@ -419,7 +437,9 @@ module Aws
         # Create a minimal mock Rack environment hash to test just what we need
         def create_mock_env
           mock_env = {
-            'HTTP_X_FORWARDED_FOR' => remote_ip,
+            # Settable independently of remote_addr: X-Forwarded-For is client
+            # supplied, so specs need to be able to forge it on its own.
+            'HTTP_X_FORWARDED_FOR' => forwarded_for || remote_ip,
             'REMOTE_ADDR' => remote_addr || remote_ip,
             'HTTP_USER_AGENT' => user_agent
           }


### PR DESCRIPTION
*This description was AI generated.*

## The attack is one HTTP request

Someone on a machine at `172.31.5.20` — another container, another EC2 instance, anything on the private network — sends this:

```
POST / HTTP/1.1
User-Agent: aws-sqsd/1.1        <- they typed this
X-Forwarded-For: 172.17.0.1     <- they typed this
{"job_class":"MoneyJob","arguments":[999,1234,50000], ...}
```

That's it. No exploit, no crash, no memory corruption. A normal request with two chosen headers and a chosen body. It can be sent with curl.

**Before this change:**

```
APP REPLIES:  200 Successfully ran job MoneyJob.
SIDE EFFECT:  MOVED $50000 from account 999 to account 1234
```

**After:**

```
APP REPLIES:  403 Request with aws-sqsd user agent was made from untrusted address.
SIDE EFFECT:  (nothing happened)
```

Same request.

## Why the app said yes

The middleware asked two questions.

**"Are you sqsd?"** Checks the `User-Agent`. The attacker typed `aws-sqsd/1.1`, so it passes. This was never security — a `User-Agent` is just text the sender picks.

**"Are you local?"** This is the real gate, and it accepted either of two answers:

```ruby
default_docker_ips.include?(request.remote_ip) ||     # <- attacker controls this
  default_docker_ips.include?(request.remote_addr)    # <- attacker cannot
```

`remote_addr` is `172.31.5.20`, the attacker's real address, which does not match. But `remote_ip` is computed from the `X-Forwarded-For` header they typed, so it resolved to `172.17.0.1` — which is on the allowed list. First operand true, `||` short-circuits, the second is never evaluated. Gate passed, job executed.

`remote_ip` resolves to the forged value because Rack walks the `X-Forwarded-For` chain from the right and skips addresses it considers infrastructure. The Docker gateway range `172.16.0.0/12` is one of the private ranges Rack treats as a trusted proxy to see through, so the forged value is never judged as a client claim — it is skipped as a hop. With every entry in the chain private, Rack falls through to returning the leftmost value, which is the attacker's own string.

## In one sentence

The middleware decided "you're local" by reading a header the attacker wrote.

## The change

Drop the `remote_ip` operand, so the decision uses only `remote_addr` — the address the operating system observed the connection arriving from, which no header can influence:

```ruby
def ip_originates_from_docker_host?(request)
  remote_addr = request.remote_addr
  default_docker_ips.include?(remote_addr) ||
    ::ActionDispatch::Request::LOCALHOST.match?(remote_addr)
end
```

Loopback is accepted alongside the Docker IPs because such a request is genuinely local — `request.local?` rejects it only on the forgeable half of its own check (`LOCALHOST.match?(remote_addr) && LOCALHOST.match?(remote_ip)`). Without this clause, a proxy running on loopback inside the container would newly receive a 403.

`remote_ip` remains correct and useful for logging and rate limiting. The change is only that it no longer makes an authorization decision.

## Why `remote_ip` was there

It was the original check. Before #156 the condition was `default_gw_ips.include?(request.ip)`, using `remote_ip` alone. `remote_addr` was added in #156 to fix the 403s reported in #154, where `remote_ip` was `127.0.0.1` while `remote_addr` was the Docker gateway. `remote_ip` was kept in an `||` for backward compatibility rather than replaced, which turned it from the sole check into an independently sufficient one.

## Impact on normal traffic

None. Ordinary requests exit the middleware before the origin check runs:

```ruby
return @app.call(env) unless from_sqs_daemon?(request)
```

Any request whose `User-Agent` does not start with `aws-sqsd` is passed straight through, so browser and API traffic — through any number of load balancers — never reaches the changed code.

Legitimate daemon topologies were each checked against the new condition:

| Scenario | `remote_addr` | `remote_ip` | Result |
|---|---|---|---|
| sqsd over loopback | `127.0.0.1` | `127.0.0.1` | 200 |
| sqsd over the Docker bridge | `172.17.0.1` | `172.17.0.1` | 200 |
| host nginx proxying in (the #154 case) | `172.17.0.1` | `127.0.0.1` | 200 |
| proxy on loopback inside the container | `127.0.0.1` | `172.17.0.1` | 200 |
| private peer + forged `X-Forwarded-For` | `172.31.5.20` | `172.17.0.1` | **403** |

The one case that changes is the last, where the peer is neither loopback nor a Docker gateway and its only claim to being local was the header it supplied.

## What this does not fix

Requests arriving via the host's port 80 are proxied into the container by the host, so the container observes the Docker gateway as the peer address — truthfully, with nothing forged. That is indistinguishable from real sqsd from inside the container, and it is not fixable in gem code.

The two paths are distinct: this change closes direct connections to the container (a sibling container, another host on the network, an SSRF pivot), where the source address is preserved and forging the header was the whole attack. Network-level controls close the proxied path. The README has been updated to state this split, and `job_class_allowlist` (added in #172) remains available to limit what a request that does get through can reach.

## Testing

- Two boundary specs added: untrusted peer plus forged `X-Forwarded-For` is forbidden; loopback peer plus gateway `X-Forwarded-For` is allowed.
- `create_mock_env` previously defaulted `REMOTE_ADDR` to `remote_ip`, so the two could not be set independently and no spec exercised `remote_ip` alone. A `forwarded_for` let makes them independent. The `when remote ip is default docker gw` context set both values identically, making it a duplicate of the `remote_addr` case that could not detect a regression in either direction; it is replaced by the two boundary specs.
- Full suite passing (114 examples), RuboCop clean.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
